### PR TITLE
subscribe(): fix the error_log string on API error

### DIFF
--- a/includes/integrations/class-integration.php
+++ b/includes/integrations/class-integration.php
@@ -293,7 +293,7 @@ abstract class MC4WP_Integration {
 		if ( $result !== true && $api->has_error() ) {
 
 			// log error
-			error_log( sprintf( 'MailChimp for WordPres (%s): %s', date( 'Y-m-d H:i:s' ), $this->type, $api->get_error_message() ) );
+			error_log( sprintf( 'MailChimp for WordPress (%s): %s: %s', date( 'Y-m-d H:i:s' ), $this->type, $api->get_error_message() ) );
 
 			if( $this->show_error_messages() ) {
 				wp_die( '<h3>' . __( 'MailChimp for WordPress - Error', 'mailchimp-for-wp' ) . '</h3>' .


### PR DESCRIPTION
Before this patch, the error message returned by the API would not be printed in the error_log. Fix a minor typo on the way.

Sponsored-by: hkdigital. (http://hkdigital.ch/)