### PR TITLE
Save dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "browserify": "^12.0.1",
     "buffer": "^3.5.2",
     "glob": "^6.0.1",
+    "globby": "^4.0.0",
     "gulp": "^3.9.0",
     "gulp-cssmin": "^0.1.7",
     "gulp-git": "^1.6.0",
@@ -22,6 +23,7 @@
     "merge-stream": "^1.0.0",
     "minimist": "^1.2.0",
     "through2": "^2.0.0",
+    "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.6.1"
   },


### PR DESCRIPTION
Save dev dependencies that are used in `gulpfile.js`.