### PR TITLE
Removed autofill attribute from honeypot

### DIFF
--- a/includes/forms/class-form-element.php.php
+++ b/includes/forms/class-form-element.php.php
@@ -77,7 +77,7 @@ class MC4WP_Form_Element {
 	public function get_hidden_fields() {
 
 		// hidden fields
-		$hidden_fields = '<div style="display: none;"><input type="text" name="_mc4wp_honeypot" value="" tabindex="-1" autocomplete="off" autofill="off" /></div>';
+		$hidden_fields =  '<div style="display: none;"><input type="text" name="_mc4wp_honeypot" value="" tabindex="-1" autocomplete="off" /></div>';
 		$hidden_fields .= '<input type="hidden" name="_mc4wp_timestamp" value="'. time() . '" />';
 		$hidden_fields .= '<input type="hidden" name="_mc4wp_form_id" value="'. esc_attr( $this->form->ID ) .'" />';
 		$hidden_fields .= '<input type="hidden" name="_mc4wp_form_element_id" value="'. esc_attr( $this->ID ) .'" />';


### PR DESCRIPTION
This is not a real HTML5 attribute and causes validation tests to fail. Fixes #227.