### PR TITLE
Enable MailChimp list subscription in BuddyPress multisite

### DIFF
--- a/integrations/buddypress/class-buddypress.php
+++ b/integrations/buddypress/class-buddypress.php
@@ -29,22 +29,138 @@ class MC4WP_BuddyPress_Integration extends MC4WP_User_Integration {
 			add_action( 'bp_before_registration_submit_buttons', array( $this, 'output_checkbox' ), 20 );
 		}
 
-		add_action( 'bp_core_signup_user', array( $this, 'subscribe_from_buddypress' ), 10, 4 );
+		if ( is_multisite() ) {
+
+			/**
+			 * Multisite signups are a two-stage process - the data is first added to
+			 * the 'signups' table and then converted into an actual user during the
+			 * activation process.
+			 *
+			 * To avoid all signups being subscribed to the MailChimp list until they
+			 * have responded to the activation email, a value is stored in the signup
+			 * usermeta data which is retrieved on activation and acted upon.
+			 */
+			add_filter( 'bp_signup_usermeta', array( $this, 'store_usermeta' ), 10, 1 );
+			add_action( 'bp_core_activated_user', array( $this, 'subscribe_from_usermeta' ), 10, 3 );
+
+		} else {
+			add_action( 'bp_core_signup_user', array( $this, 'subscribe_from_form' ), 10, 4 );
+		}
+
+		/**
+		 * There is one further issue to consider, which is that many BuddyPress
+		 * installs have a user moderation plugin (e.g. BP Registration Options)
+		 * installed. This is because email activation is not enough to ensure
+		 * that user signups are not spammers. There should therefore be a way for
+		 * plugins to delay the MailChimp signup process.
+		 *
+		 * A plugin can hook into the 'mc4wp_delay_subscription' filter to prevent
+		 * subscriptions from taking place on activation:
+		 *
+		 * add_filter( 'mc4wp_delay_subscription', 'my_delay_function' );
+		 * function my_delay_function( $user_id ) {
+		 *     // store a flag in their usermeta, for example
+		 *     return false;
+		 * }
+		 *
+		 * The plugin would then then call:
+		 *
+		 * do_action( 'mc4wp_do_delayed_subscription', $user_id );
+		 *
+		 * to perform the subscription at a later point.
+		 */
+		add_action( 'mc4wp_do_delayed_subscription', array( $this, 'subscribe_buddypress_user' ), 10, 1 );
+
 	}
 
 	/**
-	 * Subscribes from BuddyPress Registration Form
+	 * Subscribes from BuddyPress Registration Form.
+	 *
 	 * @param int $user_id
 	 * @param string $user_login
 	 * @param string $user_password
 	 * @param string $user_email
 	 * @return bool
 	 */
-	public function subscribe_from_buddypress( $user_id, $user_login, $user_password, $user_email ) {
+	public function subscribe_from_form( $user_id, $user_login, $user_password, $user_email ) {
 
 		if ( ! $this->triggered() ) {
 			return false;
 		}
+
+		/**
+		 * Allow other plugins to delay MailChimp subscription.
+		 *
+		 * @param bool False does not delay subscription (default)
+		 * @param int $user_id The user ID to subscribe
+		 * @return bool False does not delay subscription, otherwise enforces delay
+		 */
+		if ( false !== apply_filters( 'mc4wp_delay_subscription', false, $user_id ) ) {
+			return;
+		}
+
+		$this->subscribe_buddypress_user( $user_id );
+	}
+
+	/**
+	 * Stores subscription data from BuddyPress Registration Form.
+	 *
+	 * @param array $usermeta The existing usermeta
+	 * @return array $usermeta The modified usermeta
+	 */
+	public function store_usermeta( $usermeta ) {
+
+		// do not subscribe if not triggered
+		if ( ! $this->triggered() ) {
+			$usermeta['mc4wp_delayed_subscribe'] = 'n';
+		} else {
+			$usermeta['mc4wp_delayed_subscribe'] = 'y';
+		}
+
+		return $usermeta;
+	}
+
+	/**
+	 * Subscribes from BuddyPress Activation.
+	 *
+	 * @param int $user_id The activated user ID
+	 * @param string $key the activation key (not used)
+	 * @param array $userdata An array containing the activated user data
+	 */
+	public function subscribe_from_usermeta( $user_id, $key, $userdata ) {
+
+		if ( empty( $user_id ) ) {
+			return false;
+		}
+
+		// get metadata
+		$meta = ( isset( $userdata['meta'] ) ) ? $userdata['meta'] : array();
+
+		// bail if usermeta key doesn't exist or user chose not to subscribe
+		if ( ! isset( $meta['mc4wp_delayed_subscribe'] ) || $meta['mc4wp_delayed_subscribe'] == 'n' ) {
+			return false;
+		}
+
+		/**
+		 * Allow other plugins to delay MailChimp subscription.
+		 *
+		 * @param bool False does not delay subscription (default)
+		 * @param int $user_id The user ID to subscribe
+		 * @return bool False does not delay subscription, otherwise enforces delay
+		 */
+		if ( false !== apply_filters( 'mc4wp_delay_subscription', false, $user_id ) ) {
+			return;
+		}
+
+		$this->subscribe_buddypress_user( $user_id );
+	}
+
+	/**
+	 * Subscribes a user to MailChimp list(s).
+	 *
+	 * @param int $user_id The user ID to subscribe
+	 */
+	public function subscribe_buddypress_user( $user_id ) {
 
 		$user = get_userdata( $user_id );
 
@@ -53,7 +169,7 @@ class MC4WP_BuddyPress_Integration extends MC4WP_User_Integration {
 			return false;
 		}
 
-		// gather emailadress and name from user who BuddyPress registered
+		// gather email address and name from user
 		$data = $this->user_merge_vars( $user );
 
 		return $this->subscribe( $data, $user_id );


### PR DESCRIPTION
In WordPress Multisite with BuddyPress enabled, signups are a two-stage process - the data is first added to the 'signups' table and then converted into an actual user during the activation process. This means that (for this plugin at present) users are not being subscribed to MailChimp lists, since the `$user_id` does not exist when the `bp_core_signup_user` hook is fired.

To avoid all signups being subscribed to the MailChimp list until they have responded to the activation email, the code in this PR stores a value in the signup usermeta data which is retrieved on activation and acted upon.

However there is one further issue to consider: many BuddyPress installs have a user moderation plugin (e.g. [BP Registration Options](https://wordpress.org/plugins/bp-registration-options/)) installed. This is because email activation is not enough to ensure that user signups are not spammers - they often are - and subscribing spammers to the MailChimp list(s) is undesirable.

I have therefore included a way for plugins to delay the MailChimp signup process until members have been moderated. This is done with a new filter called `mc4wp_delay_subscription` and a new action called `mc4wp_do_delayed_subscription`. A plugin can hook into the 'mc4wp_delay_subscription' filter to prevent subscriptions from taking place on activation:

``` php
add_filter( 'mc4wp_delay_subscription', 'my_delay_function' );
function my_delay_function( $user_id ) {
    // store a flag in their usermeta, for example
    return false;
}
```

The plugin would then then call:

`do_action( 'mc4wp_do_delayed_subscription', $user_id );`

to perform the subscription at a later point. You can see [some functioning code in this Gist](https://gist.github.com/christianwach/aab0f25b831fd914ac3fe45577c7d218) that works with BP Registration Options.
