### PR TITLE
Fix BuddyPress signups in WordPress Multisite

### DIFF
--- a/integrations/buddypress/class-buddypress.php
+++ b/integrations/buddypress/class-buddypress.php
@@ -138,7 +138,7 @@ class MC4WP_BuddyPress_Integration extends MC4WP_User_Integration {
 			return false;
 		}
 
-		$subscribe = false;
+		$subscribe = true;
 
         /**
          * @ignore Documented elsewhere, see MC4WP_BuddyPress_Integration::subscribe_from_form.


### PR DESCRIPTION
This PR fixes a bug in the commit for #363 which prevents signups from happening by default in WordPress Multisite.

FWIW, I didn't notice this because my filter was returning the appropriate value, but when I switched off user moderation, it became clear that [signups can never happen with the logic as it stands](https://github.com/ibericode/mailchimp-for-wordpress/blob/master/integrations/buddypress/class-buddypress.php#L141-L149) because `$subscribe` will always remain `false`.