### PR TITLE
Add nonce verification when a form is processed

### DIFF
--- a/includes/forms/class-form-element.php
+++ b/includes/forms/class-form-element.php
@@ -83,6 +83,7 @@ class MC4WP_Form_Element {
 		$hidden_fields .= '<input type="hidden" name="_mc4wp_timestamp" value="'. time() . '" />';
 		$hidden_fields .= '<input type="hidden" name="_mc4wp_form_id" value="'. esc_attr( $this->form->ID ) .'" />';
 		$hidden_fields .= '<input type="hidden" name="_mc4wp_form_element_id" value="'. esc_attr( $this->ID ) .'" />';
+		$hidden_fields .= wp_nonce_field( 'mc4wp-process-form-' . $this->form->ID, '_mc4wp_form_nonce', true, false );
 
 		// was "lists" parameter passed in shortcode arguments?
 		if( ! empty( $this->config['lists'] ) ) {

--- a/includes/forms/class-form-listener.php
+++ b/includes/forms/class-form-listener.php
@@ -37,6 +37,11 @@ class MC4WP_Form_Listener {
 			return false;
 		}
 
+		$nonce = isset( $request['_mc4wp_form_nonce'] ) ? $request['_mc4wp_form_nonce'] : '';
+		if ( ! wp_verify_nonce( $nonce, 'mc4wp-process-form-' . $form_id ) ) {
+			wp_die( __( 'Sorry, you are not allowed to process this form.', 'mailchimp-for-wp' ) );
+		}
+
 		// where the magic happens
 		$form->handle_request( $_POST );
 		$form->validate();


### PR DESCRIPTION
Forms are processed without nonces verification: https://codex.wordpress.org/WordPress_Nonces opening the possibility to cause a CSRF attack: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)