### PR TITLE
Associate labels implicitly for improved accessibility

### DIFF
--- a/config/default-form-content.php
+++ b/config/default-form-content.php
@@ -4,8 +4,8 @@ $email_label        = __('Email address', 'mailchimp-for-wp');
 $email_placeholder  = __('Your email address', 'mailchimp-for-wp');
 $signup_button      = __('Sign up', 'mailchimp-for-wp');
 
-$content = "<p>\n\t<label>{$email_label}: </label>\n";
-$content .= "\t<input type=\"email\" name=\"EMAIL\" placeholder=\"{$email_placeholder}\" required />\n</p>\n\n";
+$content = "<p>\n\t<label>{$email_label}: \n";
+$content .= "\t\t<input type=\"email\" name=\"EMAIL\" placeholder=\"{$email_placeholder}\" required />\n</label>\n</p>\n\n";
 $content .= "<p>\n\t<input type=\"submit\" value=\"{$signup_button}\" />\n</p>";
 
 return $content;


### PR DESCRIPTION
Wrapping the email field inside its label for improving accessibility.

This change follows the recommendation in:
https://wordpress.org/support/topic/small-change-for-accessibility/ 

References and further reading:
- https://dequeuniversity.com/rules/axe/3.0/label-title-only (see: Implicit labels)
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label