### PR TITLE
Suppress form scripts on AMP pages

### DIFF
--- a/includes/forms/class-asset-manager.php
+++ b/includes/forms/class-asset-manager.php
@@ -141,6 +141,11 @@ class MC4WP_Form_Asset_Manager {
 	 * Load JavaScript files
 	 */
 	public function before_output_form() {
+		$load_scripts = apply_filters( 'mc4wp_load_form_scripts', true );
+		if ( ! $load_scripts ) {
+			return;
+		}
+
 		// print dummy JS
 		$this->print_dummy_javascript();
 

--- a/includes/forms/class-form-amp.php
+++ b/includes/forms/class-form-amp.php
@@ -11,6 +11,7 @@ class MC4WP_Form_AMP {
 	public function add_hooks() {
 		add_filter( 'mc4wp_form_content', array( $this, 'add_response_templates' ), 10, 2 );
 		add_filter( 'mc4wp_form_element_attributes', array( $this, 'add_amp_request' ) );
+		add_filter( 'mc4wp_load_form_scripts', array( $this, 'suppress_scripts' ) );
 	}
 
 	/**
@@ -69,5 +70,19 @@ class MC4WP_Form_AMP {
 		}
 
 		return $attributes;
+	}
+
+	/**
+	 * Suppress form scripts on AMP pages.
+	 *
+	 * @param bool $load_scripts Whether scripts should be loaded.
+	 * @return bool Modified $load_scripts.
+	 */
+	public function suppress_scripts( $load_scripts ) {
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return false;
+		}
+
+		return $load_scripts;
 	}
 }


### PR DESCRIPTION
This PR makes a couple small changes to improve the AMP-compatibility of forms.

1. It adds the `mc4wp_load_form_scripts` filter to the `MC4WP_Form_Asset_Manager::before_output_form` method. Currently if you disable form scripts using that filter, the dummy JS still gets output.
2. Don't load form scripts on AMP pages. The AMP plugin strips the scripts out so the forms are not currently breaking anything, but they are displaying errors in the AMP validator which can confuse users.

To test:
1. Install and activate the official AMP plugin. Set AMP mode to Standard.
2. Insert an MC4WP block. Observe AMP validation errors (everything should work OK, though):
<img width="549" alt="Screen Shot 2020-04-08 at 9 49 39 AM" src="https://user-images.githubusercontent.com/7317227/78811270-712f8000-797e-11ea-8678-56ae53be18d2.png">
<img width="1212" alt="Screen Shot 2020-04-08 at 9 22 54 AM" src="https://user-images.githubusercontent.com/7317227/78811278-74c30700-797e-11ea-9fd1-78007d60d20e.png">
3. Apply this patch. Recheck the validation errors. Observe they are fixed:
<img width="1204" alt="Screen Shot 2020-04-08 at 9 23 27 AM" src="https://user-images.githubusercontent.com/7317227/78811328-899f9a80-797e-11ea-963c-58ff4fb32feb.png">

