### PR TITLE
Added option to skip merge fields when subscribing

### DIFF
--- a/includes/api/class-api-v3.php
+++ b/includes/api/class-api-v3.php
@@ -237,13 +237,18 @@ class MC4WP_API_V3 {
 	 *
 	 * @param string $list_id
 	 * @param array $args
+	 * @param bool $skip_merge_validation Allow subscribing users without all required MERGE fields
 	 *
 	 * @return object
 	 * @throws MC4WP_API_Exception
 	 */
-	public function add_list_member( $list_id, array $args ) {
+	public function add_list_member( $list_id, array $args, $skip_merge_validation = false ) {
 		$subscriber_hash = $this->get_subscriber_hash( $args['email_address'] );
 		$resource        = sprintf( '/lists/%s/members/%s', $list_id, $subscriber_hash );
+    
+		if ( $skip_merge_validation ) {
+			$resource = add_query_arg( array( 'skip_merge_validation' => 'true' ), $resource );
+		}
 
 		// make sure we're sending an object as the Mailchimp schema requires this
 		if ( isset( $args['merge_fields'] ) ) {


### PR DESCRIPTION
The [MailChimp API for `PUT /lists/{list_id}/members/{subscriber_hash}`](https://mailchimp.com/developer/reference/lists/list-members/#put_/lists/-list_id-/members/-subscriber_hash-) supports a boolean query parameter called `skip_merge_validation` which allows the developer to subscribe new members with some required MERGE fields missing.

> Request Query Parameters
skip_merge_validation
type: Boolean
title: Skip Merge Validation
read only: False
> > If skip_merge_validation is true, member data will be accepted without merge field values, even if the merge field is usually required. This defaults to False.
Possible Values: true false


I added this option to your `MC4WP_API_V3->add_list_member()` function which calls the `PUT` API and tested it successfully.

I hope you will merge this pull request because we need it in our website :)