### PR TITLE
Add method to the api to create templates

### DIFF
--- a/includes/api/class-api-v3.php
+++ b/includes/api/class-api-v3.php
@@ -1123,13 +1123,12 @@ class MC4WP_API_V3 {
 	 *
 	 * @link https://mailchimp.com/developer/reference/templates/#post_/templates
 	 * @param array $args
-	 *
 	 * @return object
 	 * @throws MC4WP_API_Exception
 	 */
-	public function add_template(array $args) {
+	public function add_template( array $args ) {
 		$resource = '/template';
-		return $this->client->post( $resource, $args);
+		return $this->client->post( $resource, $args );
 	}
 
 	/**

--- a/includes/api/class-api-v3.php
+++ b/includes/api/class-api-v3.php
@@ -1091,7 +1091,6 @@ class MC4WP_API_V3 {
 		return ! ! $this->client->delete( $resource );
 	}
 
-
 	/**
 	 * Get a list of an account's available templates
 	 *
@@ -1117,6 +1116,20 @@ class MC4WP_API_V3 {
 	public function get_template( $template_id, array $args = array() ) {
 		$resource = sprintf( '/templates/%s', $template_id );
 		return $this->client->get( $resource, $args );
+	}
+
+	/**
+	 * Create a new template.
+	 *
+	 * @link https://mailchimp.com/developer/reference/templates/#post_/templates
+	 * @param array $args
+	 *
+	 * @return object
+	 * @throws MC4WP_API_Exception
+	 */
+	public function add_template(array $args) {
+		$resource = '/template';
+		return $this->client->post( $resource, $args);
 	}
 
 	/**


### PR DESCRIPTION
In mc4wp-premium we are creating a new feature. It depends on this
method.
Create a method which do post call to the mailchimp api endpoint
`/template`.
https://mailchimp.com/developer/reference/templates/#post_/templates