### PR TITLE
Support WP 5.5: REST API Endpoint Permissions Callback

### DIFF
--- a/includes/forms/class-form-manager.php
+++ b/includes/forms/class-form-manager.php
@@ -134,6 +134,7 @@ class MC4WP_Form_Manager {
 				'methods'  => 'POST',
 				'permission_callback' => '__return_true',
 				'callback' => array( $this, 'handle_endpoint' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 	}


### PR DESCRIPTION
Info from Docs:
https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback
https://core.trac.wordpress.org/changeset/48526