### PR TITLE
Fix Issue 705 (_doing_it_wrong notice).

### DIFF
--- a/includes/forms/class-form-manager.php
+++ b/includes/forms/class-form-manager.php
@@ -134,6 +134,7 @@ class MC4WP_Form_Manager {
 				'methods'  => 'POST',
 				'permission_callback' => '__return_true',
 				'callback' => array( $this, 'handle_endpoint' ),
+				'permission_callback' => '__return_true'
 			)
 		);
 	}


### PR DESCRIPTION
**From Wordpress official documentation**
As of WordPress 5.5, if a permission_callback is not provided, the REST API will issue a _doing_it_wrong notice.
For REST API routes that are intended to be public, use __return_true as the permission callback.