### PR TITLE
Update form-settings.php

### DIFF
--- a/includes/forms/views/tabs/form-settings.php
+++ b/includes/forms/views/tabs/form-settings.php
@@ -8,7 +8,7 @@
 
 	<?php
 	/** @ignore */
-	do_action( 'mc4wp_admin_form_after_mailchimp_settings_rows', $opts, $form );
+	do_action( 'mc4wp_admin_form_before_mailchimp_settings_rows', $opts, $form );
 	?>
 
 	<tr valign="top">


### PR DESCRIPTION
I think this is a longstanding typo. The action hook in question is actually run **before** the rows are output. (And there is already another hook with the same name at the end of this file, **after** the rows are output.