### PR TITLE
Change "_mc4wp_settings" to copy-once from copy in wpml-config.xml

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -3,7 +3,7 @@
 		<custom-type translate="1">mc4wp-form</custom-type>
 	</custom-types>
 	<custom-fields>
-		<custom-field action="copy">_mc4wp_settings</custom-field>
+		<custom-field action="copy-once">_mc4wp_settings</custom-field>
 		<custom-field action="translate">text_subscribed</custom-field>
 		<custom-field action="translate">text_error</custom-field>
 		<custom-field action="translate">text_invalid_email</custom-field>


### PR DESCRIPTION
Hi, I am Sumit from WPML.

We got a [report from a customer](https://wpml.org/forums/topic/cannot-choose-different-list-on-third-language/) that they can not choose a list per language.
On debugging the issue we found that `_mc4wp_settings` is set to `copy` so it overwrites the user-defined list with original form settings.

We'd suggest setting this custom field to `copy-once` so when translating the form first time the setting will be copied but later customers can modify it and can have a different list for each language.
We have also corrected it here https://github.com/OnTheGoSystems/wpml-config/pull/237