### PR TITLE
Move the checkbox closer to the email form element

### DIFF
--- a/integrations/give/class-give.php
+++ b/integrations/give/class-give.php
@@ -13,7 +13,7 @@ class MC4WP_Give_Integration extends MC4WP_Integration {
 
 	public function add_hooks() {
 		if ( ! $this->options['implicit'] ) {
-			add_action( 'give_donation_form_top', array( $this, 'output_checkbox' ), 50 );
+			add_action( 'give_purchase_form_register_login_fields', array( $this, 'output_checkbox' ), 50 );
 		}
 
 		add_action( 'give_checkout_before_gateway', array( $this, 'subscribe_from_give' ), 90, 2 );


### PR DESCRIPTION
This GiveWP hook (taken from https://givewp.com/add-content-donation-forms/) moves the sign up checkbox directly after the email address input, rather than closer to the top of the donation form.