### PR TITLE
fix: fix issue with marketing_permissions casting

### DIFF
--- a/includes/api/class-api-v3.php
+++ b/includes/api/class-api-v3.php
@@ -240,7 +240,7 @@ class MC4WP_API_V3 {
 		}
 
 		if ( isset( $args['marketing_permissions'] ) ) {
-			$args['marketing_permissions'] = (object) $args['marketing_permissions'];
+			$args['marketing_permissions'] = (array) $args['marketing_permissions'];
 		}
 
 		return $this->client->post( $resource, $args );
@@ -276,7 +276,7 @@ class MC4WP_API_V3 {
 		}
 
 		if ( isset( $args['marketing_permissions'] ) ) {
-			$args['marketing_permissions'] = (object) $args['marketing_permissions'];
+			$args['marketing_permissions'] = (array) $args['marketing_permissions'];
 		}
 
 		// "put" updates the member if it's already on the list... take notice
@@ -307,7 +307,7 @@ class MC4WP_API_V3 {
 		}
 
 		if ( isset( $args['marketing_permissions'] ) ) {
-			$args['marketing_permissions'] = (object) $args['marketing_permissions'];
+			$args['marketing_permissions'] = (array) $args['marketing_permissions'];
 		}
 
 		return $this->client->patch( $resource, $args );


### PR DESCRIPTION
### The issue
marketing_permissions must be an array of objects when sent to Mailchimp according to the specs:
https://mailchimp.com/developer/marketing/api/list-merges/

### How can we reproduce this issue?
1. Use the filter `mc4wp_form_subscriber_data` to add `marketing_permissions` property to the subscriber.
2. Use the api to add/update a list member `PUT /lists/{list_id}/members/{subscriber_hash}`
3. The response message you get is a `400 Bad Request`

### Technical info
* WordPress version: 6.1.1
* Mailchimp for WordPress version: 4.9.0 