### PR TITLE
Disable position field when woocommerce integration is disabled

### DIFF
--- a/assets/src/js/admin/show-if.js
+++ b/assets/src/js/admin/show-if.js
@@ -13,6 +13,7 @@ function toggleElement (el, hide, input, condition) {
     el.style.visibility = conditionMet ? '' : 'hidden'
   } else {
     el.style.opacity = conditionMet ? '' : '0.4'
+    el.style.pointerEvents = conditionMet ? '' : 'none'
   }
 
   // disable input fields inside this element to stop sending their values to server

--- a/integrations/woocommerce/admin-after.php
+++ b/integrations/woocommerce/admin-after.php
@@ -17,28 +17,35 @@ if ( defined( 'CFW_NAME' ) ) {
 
 /** @var MC4WP_Integration $integration */
 
+$body_config = array(
+	'element' => 'mc4wp_integrations[' . $integration->slug . '][enabled]',
+	'value'   => '1',
+	'hide'    => false,
+);
+
+$config = array(
+	'element' => 'mc4wp_integrations[' . $integration->slug . '][implicit]',
+	'value'   => '0',
+);
+
 ?>
 <table class="form-table">
-	<?php
-	$config = array(
-		'element' => 'mc4wp_integrations[' . $integration->slug . '][implicit]',
-		'value'   => '0',
-	);
-	?>
-	<tr valign="top" data-showif="<?php echo esc_attr( json_encode( $config ) ); ?>">
-		<th scope="row">
-			<?php _e( 'Position', 'mailchimp-for-wp' ); ?>
-		</th>
-		<td>
-			<select name="mc4wp_integrations[<?php echo $integration->slug; ?>][position]">
-				<?php
+	<tbody class="integration-toggled-settings" data-showif="<?php echo esc_attr( json_encode( $body_config ) ); ?>">
+		<tr valign="top" data-showif="<?php echo esc_attr( json_encode( $config ) ); ?>">
+			<th scope="row">
+				<?php _e( 'Position', 'mailchimp-for-wp' ); ?>
+			</th>
+			<td>
+				<select name="mc4wp_integrations[<?php echo $integration->slug; ?>][position]">
+					<?php
 
-				foreach ( $position_options as $value => $label ) {
-					printf( '<option value="%s" %s>%s</option>', esc_attr( $value ), selected( $value, $opts['position'], false ), esc_html( $label ) );
-				}
-				?>
+					foreach ( $position_options as $value => $label ) {
+						printf( '<option value="%s" %s>%s</option>', esc_attr( $value ), selected( $value, $opts['position'], false ), esc_html( $label ) );
+					}
+					?>
 
-			</select>
-		</td>
-	</tr>
+				</select>
+			</td>
+		</tr>
+	</tbody>
 </table>


### PR DESCRIPTION
This PR closes #765.
The position field is now disabled when WooCommerce integration is not enabled. Additionally, I have added `pointer-events: none;'` to prevent the disabled fields from being clicked or edited."