### PR TITLE
Add default label in woocommerce checkout

### DIFF
--- a/includes/integrations/class-integration.php
+++ b/includes/integrations/class-integration.php
@@ -163,6 +163,10 @@ abstract class MC4WP_Integration {
 		$integration = $this;
 		$label       = $this->options['label'];
 
+		if(!$label){
+			$label = $this->get_default_options()['label'];
+		}
+
 		/**
 		 * Filters the checkbox label
 		 *


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22478965/235303362-09eaf2b1-44c3-4031-b778-e7b12cdb3c50.png)

The label field is required. But there's no server-side validation. In this PR I have used the default label if the field is empty. It will also help us translate the label on multilingual site. Currently there is no way to add different label for each language. 