### PR TITLE
[WPML] Added text_no_lists_selected to the config file

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -12,6 +12,7 @@
 		<custom-field action="translate">text_unsubscribed</custom-field>
 		<custom-field action="translate">text_not_subscribed</custom-field>
 		<custom-field action="translate">text_subscribed</custom-field>
+		<custom-field action="translate">text_no_lists_selected</custom-field>
 	</custom-fields>
 	<admin-texts>
 		<key name="mc4wp_integrations">


### PR DESCRIPTION
Hi there, this is DIego from the WPML Compatibility Team.

We did some tests with the plugin (ticket ID: mcml-6) and found that the text_no_lists_selected field was missing from the wpml config file. This way the field was not being translated.

After registering the field in the config file, the problem is fixed.
