### PR TITLE
Option to send an email when an error is logged

### DIFF
--- a/includes/class-debug-log.php
+++ b/includes/class-debug-log.php
@@ -139,6 +139,19 @@ class MC4WP_Debug_Log
         // unlock file again, but don't close it for remainder of this request
         flock($this->stream, LOCK_UN);
 
+        if ($level >= self::ERROR) {
+            $opts = mc4wp_get_options();
+            if (! empty($opts['email_on_error'])) {
+                $last_sent = get_transient('mc4wp_error_email_sent');
+                if (! $last_sent) {
+                    $subject = sprintf('[%s] MC4WP Error on your site', get_bloginfo('name'));
+                    $body    = sprintf('A MC4WP error occurred on your site: %s', $message);
+                    wp_mail($opts['email_on_error'], $subject, $body);
+                    set_transient('mc4wp_error_email_sent', time(), DAY_IN_SECONDS);
+                }
+            }
+        }
+
         return true;
     }
 

--- a/includes/views/other-settings.php
+++ b/includes/views/other-settings.php
@@ -47,6 +47,17 @@ defined('ABSPATH') or exit;
                             </td>
                         </tr>
                     </table>
+                    <table class="form-table">
+                        <tr>
+                            <th><label for="mc4wp-email-on-error"><?php echo esc_html__('Send email on critical error', 'mailchimp-for-wp'); ?></label></th>
+                            <td>
+                                <input type="email" id="mc4wp-email-on-error" name="mc4wp[email_on_error]" value="<?php echo esc_attr($opts['email_on_error']); ?>" class="regular-text" placeholder="your@email.com" />
+                                <p class="description">
+                                    <?php echo esc_html__('Enter an email address to receive a notification when a critical error occurs. Max 1 email per 24 hours.', 'mailchimp-for-wp'); ?>
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
 
                 <?php do_action('mc4wp_admin_other_settings', $opts); ?>


### PR DESCRIPTION
#162 Notify site administrator when forms stop working 

Takes an email address as setting under MC4WP > Other
When there is an  Error (400) it sends an email to this address
Rate limited to 1 email per day. 