### PR TITLE
In class-list-data-mapper.php - If field type is text, but an array is received, transform to comma separated string.  This allows the use of CF7 checkboxes

### DIFF
--- a/includes/class-list-data-mapper.php
+++ b/includes/class-list-data-mapper.php
@@ -161,7 +161,7 @@ class MC4WP_List_Data_Mapper
         $field_type = strtolower($merge_field->type);
 
         // Convert arrays to comma-separated strings for all non-address fields
-        if (is_array($value) && $field_type !== 'address') {
+        if (is_array($value) && $field_type == 'text') {
             $value = join(', ', $value);
         }
 


### PR DESCRIPTION
code snippet so we can close issue #452 {checkbox is passed as array instead of  ...)