### PR TITLE
Demonstrate new tag format with active and inactive status 

### DIFF
--- a/sample-code-snippets/forms/subscriber-tags.php
+++ b/sample-code-snippets/forms/subscriber-tags.php
@@ -1,13 +1,27 @@
 <?php
 
 /**
- * This adds the "My tag" tag to all new subscribers added by the plugin.
- *
  * The "mc4wp_subscriber_form_data" filter only runs for form requests.
  * Use "mc4wp_subscriber_data" to hook into both form & integration requests.
  */
 
+//This will add the tag "My tag" to all new subscribers added by the plugin.
 add_filter('mc4wp_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber) {
     $subscriber->tags[] = 'My tag';
+    return $subscriber;
+});
+
+//This will remove the tag "My tag" from all new subscribers added by the plugin.
+add_filter('mc4wp_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber) {
+    $subscriber->tags[] = ['name' => 'My Tag', 'status' => 'inactive'];
+    return $subscriber;
+});
+
+
+//You can add and remove multiple tags at once.
+add_filter('mc4wp_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber) {
+    $subscriber->tags[] = ['name' => 'My Tag', 'status' => 'active'];
+    $subscriber->tags[] = ['name' => 'Another tag', 'status' => 'active'];
+    $subscriber->tags[] = ['name' => 'Remove this tag', 'status' => 'inactive'];
     return $subscriber;
 });

--- a/sample-code-snippets/integrations/contact-form-7/different-tag.php
+++ b/sample-code-snippets/integrations/contact-form-7/different-tag.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * Add a different tag to the subscriber based on the CF7 form ID.
+ * In this example CF7 form with ID 500 will get the tag ES.
+ * The form ID 510 will get the tag NL
+ *
+ * NOTE: The ID in this case is the POST ID that you see in the URL when you edit a form.
+ * That means the ID is always a number and not the ID you see in the CF shortcode.
+ *
+ * It is also possible to remove tags, see the subscriber-tags.php snippet under /forms/
+ */
+
 add_filter('mc4wp_integration_contact-form-7_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber, $cf7_form_id) {
     if ($cf7_form_id == 500) {
         $subscriber->tags[] = 'ES';

--- a/sample-code-snippets/integrations/woocommerce/woocommerce-subscriber-tag.php
+++ b/sample-code-snippets/integrations/woocommerce/woocommerce-subscriber-tag.php
@@ -1,11 +1,26 @@
 <?php
 
 /**
- * This adds the "My tag" tag to all new subscribers added using WooCommerce Checkout integration.
+ * Add and or remove tags from subscribers added using WooCommerce Checkout integration.
  *
  */
 
+//Add the tag "My tag" to all new subscribers added using WooCommerce Checkout integration.
 add_filter('mc4wp_integration_woocommerce_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber) {
     $subscriber->tags[] = 'My tag';
+    return $subscriber;
+});
+
+
+//Remove the tag "My tag" from all new subscribers added using WooCommerce Checkout integration.
+add_filter('mc4wp_integration_woocommerce_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber) {
+    $subscriber->tags[] = ['name' => 'My tag', 'status' => 'inactive'];
+    return $subscriber;
+});
+
+//Add the tag "My tag" to all new subscribers added using WooCommerce Checkout integration while removing the "Remove me" tag.
+add_filter('mc4wp_integration_woocommerce_subscriber_data', function (MC4WP_MailChimp_Subscriber $subscriber) {
+    $subscriber->tags[] = ['name' => 'My tag', 'status' => 'active'];
+    $subscriber->tags[] = ['name' => 'Remove me', 'status' => 'inactive'];
     return $subscriber;
 });


### PR DESCRIPTION
was $subscriber->tags[] = 'My tag';
now
$subscriber->tags[] = ['name' => 'Another tag', 'status' => 'active']; $subscriber->tags[] = ['name' => 'Remove this tag', 'status' => 'inactive'];

as for the CF7 ID, CF7 shows some internal ID that is NOT the post ID so that can be confusing.