### PR TITLE
enhancement(fields): add autocomplete attributes to form fields

### DIFF
--- a/assets/src/js/admin/form-editor/field-generator.js
+++ b/assets/src/js/admin/form-editor/field-generator.js
@@ -137,6 +137,10 @@ generators.default = function (config) {
     attributes.placeholder = config.placeholder
   }
 
+  if (config.autocomplete && config.autocomplete.length > 0) {
+    attributes.autocomplete = config.autocomplete
+  }
+
   attributes.required = config.required
   attributes.oncreate = setAttributes
 
@@ -154,7 +158,7 @@ generators.procaptcha = function (config) {
  * @param {object} config
  * @returns {string}
  */
-function generate (config) {
+function generate(config) {
   const labelAtts = {}
   const label = config.label.length > 0 && config.showLabel ? m('label', labelAtts, config.label) : ''
   const field = typeof (generators[config.type]) === 'function' ? generators[config.type](config) : generators.default(config)

--- a/assets/src/js/admin/form-editor/field-manager.js
+++ b/assets/src/js/admin/form-editor/field-manager.js
@@ -10,7 +10,7 @@ const registeredFields = []
 /**
  * Reset all previously registered fields
  */
-function reset () {
+function reset() {
   // clear all of our fields
   registeredFields.forEach(fields.deregister)
   m.redraw()
@@ -23,7 +23,7 @@ function reset () {
  * @param {object} data
  * @param {boolean} sticky
  */
-function register (category, data, sticky) {
+function register(category, data, sticky) {
   const field = fields.register(category, data)
 
   if (!sticky) {
@@ -37,7 +37,7 @@ function register (category, data, sticky) {
  * @param type
  * @returns {*}
  */
-function getFieldType (type) {
+function getFieldType(type) {
   const map = {
     phone: 'tel',
     dropdown: 'select',
@@ -54,7 +54,7 @@ function getFieldType (type) {
  * @param mergeField
  * @returns {boolean}
  */
-function registerMergeField (mergeField) {
+function registerMergeField(mergeField) {
   const category = i18n.listFields
   const fieldType = getFieldType(mergeField.type)
 
@@ -66,17 +66,29 @@ function registerMergeField (mergeField) {
     forceRequired: mergeField.required,
     type: fieldType,
     choices: mergeField.options.choices,
-    acceptsMultipleValues: false // merge fields never accept multiple values.
+    choices: mergeField.options.choices,
+    acceptsMultipleValues: false, // merge fields never accept multiple values.
+    autocomplete: (function (tag) {
+      if (tag === 'FNAME') {
+        return 'given-name'
+      }
+
+      if (tag === 'LNAME') {
+        return 'family-name'
+      }
+
+      return ''
+    }(mergeField.tag))
   }
 
   if (data.type !== 'address') {
     register(category, data, false)
   } else {
-    register(category, { name: data.name + '[addr1]', type: 'text', mailchimpType: 'address', title: i18n.streetAddress }, false)
-    register(category, { name: data.name + '[city]', type: 'text', mailchimpType: 'address', title: i18n.city }, false)
-    register(category, { name: data.name + '[state]', type: 'text', mailchimpType: 'address', title: i18n.state }, false)
-    register(category, { name: data.name + '[zip]', type: 'text', mailchimpType: 'address', title: i18n.zip }, false)
-    register(category, { name: data.name + '[country]', type: 'select', mailchimpType: 'address', title: i18n.country, choices: countries }, false)
+    register(category, { name: data.name + '[addr1]', type: 'text', mailchimpType: 'address', title: i18n.streetAddress, autocomplete: 'address-line1' }, false)
+    register(category, { name: data.name + '[city]', type: 'text', mailchimpType: 'address', title: i18n.city, autocomplete: 'address-level2' }, false)
+    register(category, { name: data.name + '[state]', type: 'text', mailchimpType: 'address', title: i18n.state, autocomplete: 'address-level1' }, false)
+    register(category, { name: data.name + '[zip]', type: 'text', mailchimpType: 'address', title: i18n.zip, autocomplete: 'postal-code' }, false)
+    register(category, { name: data.name + '[country]', type: 'select', mailchimpType: 'address', title: i18n.country, choices: countries, autocomplete: 'country' }, false)
   }
 
   return true
@@ -87,7 +99,7 @@ function registerMergeField (mergeField) {
  *
  * @param interestCategory
  */
-function registerInterestCategory (interestCategory) {
+function registerInterestCategory(interestCategory) {
   const fieldType = getFieldType(interestCategory.type)
 
   const data = {
@@ -105,7 +117,7 @@ function registerInterestCategory (interestCategory) {
  *
  * @param list
  */
-function registerListFields (list) {
+function registerListFields(list) {
   // make sure EMAIL && public fields come first
   list.merge_fields = list.merge_fields.sort(function (a, b) {
     if (a.tag === 'EMAIL' || (a.public && !b.public)) {
@@ -133,7 +145,7 @@ function registerListFields (list) {
  *
  * @param lists
  */
-function registerListsFields (lists) {
+function registerListsFields(lists) {
   const url = ajaxurl + '?action=mc4wp_get_list_details&ids=' + lists.map(l => l.id).join(',')
 
   m.request({
@@ -146,13 +158,14 @@ function registerListsFields (lists) {
   })
 }
 
-function registerCustomFields (lists) {
+function registerCustomFields(lists) {
   register(i18n.listFields, {
     name: 'EMAIL',
     title: i18n.emailAddress,
     required: true,
     forceRequired: true,
-    type: 'email'
+    type: 'email',
+    autocomplete: 'email'
   }, true)
 
   // register submit button

--- a/assets/src/js/admin/form-editor/fields.js
+++ b/assets/src/js/admin/form-editor/fields.js
@@ -12,6 +12,7 @@ function Field (data) {
     showLabel: typeof (data.showLabel) === 'boolean' ? data.showLabel : true,
     value: data.value || '',
     placeholder: data.placeholder || '',
+    autocomplete: data.autocomplete || '',
     required: typeof (data.required) === 'boolean' ? data.required : false,
     forceRequired: typeof (data.forceRequired) === 'boolean' ? data.forceRequired : false,
     wrap: typeof (data.wrap) === 'boolean' ? data.wrap : true,

--- a/config/default-form-content.php
+++ b/config/default-form-content.php
@@ -5,7 +5,7 @@ $email_placeholder_attr = esc_attr__('Your email address', 'mailchimp-for-wp');
 $signup_button_value    = esc_attr__('Sign up', 'mailchimp-for-wp');
 
 $content  = "<p>\n\t<label for=\"email\">{$email_label}: \n";
-$content .= "\t\t<input type=\"email\" id=\"email\" name=\"EMAIL\" placeholder=\"{$email_placeholder_attr}\" required>\n\t</label>\n</p>\n\n";
+$content .= "\t\t<input type=\"email\" id=\"email\" name=\"EMAIL\" placeholder=\"{$email_placeholder_attr}\" autocomplete=\"email\" required>\n\t</label>\n</p>\n\n";
 $content .= "<p>\n\t<input type=\"submit\" value=\"{$signup_button_value}\">\n</p>";
 
 return $content;


### PR DESCRIPTION
## 🎯 Summary

Added `autocomplete` attributes to the form field generator and default form content to improve accessibility and user experience by allowing browsers to autofill user information.

## 📋 Issue Reference

Fixes #777

## 🔍 Problem Description

### Current Behavior
Mailchimp for WordPress form fields (Email, First Name, Last Name) do not have `autocomplete` attributes. This prevents browsers and password managers from reliably identifying these fields and offering autofill suggestions.

### Expected Behavior
-   The Email field should have `autocomplete="email"`.
-   The First Name field should have `autocomplete="given-name"`.
-   The Last Name field should have `autocomplete="family-name"`.

## ✨ Solution Overview

### Approach Taken
1.  **Updated Field Definitions**: Modified `field-manager.js` to include the `autocomplete` property.
2.  **Updated Field Generator**: Modified `field-generator.js` to render the `autocomplete` attribute.
3.  **Updated Default Content**: Modified `config/default-form-content.php` to include `autocomplete="email"`.

## 🔧 Changes Made

### Files Modified
-   `assets/src/js/admin/form-editor/fields.js`: Added `autocomplete` property to `Field` object.
-   `assets/src/js/admin/form-editor/field-manager.js`: Configured default `autocomplete` values.
-   `assets/src/js/admin/form-editor/field-generator.js`: Updated generator to output the attribute.
-   `config/default-form-content.php`: Added `autocomplete="email"`.

### Detailed Changes

#### 1. Generated Form HTML (`config/default-form-content.php`)

**Before:**
```html
<p>
	<label for="email">Email address: 
		<input type="email" id="email" name="EMAIL" placeholder="Your email address" required>
	</label>
</p>

<p>
	<input type="submit" value="Sign up">
</p>
```

**After:**
```html
<p>
	<label for="email">Email address: 
		<input type="email" id="email" name="EMAIL" placeholder="Your email address" autocomplete="email" required>
	</label>
</p>

<p>
	<input type="submit" value="Sign up">
</p>
```

#### 2. Field Generator Logic (`field-generator.js`)

**Before:**
```javascript
  if (config.placeholder.length > 0) {
    attributes.placeholder = config.placeholder
  }

  attributes.required = config.required
```

**After:**
```javascript
  if (config.placeholder.length > 0) {
    attributes.placeholder = config.placeholder
  }

  // ✅ Add autocomplete attribute if properly configured
  if (config.autocomplete && config.autocomplete.length > 0) {
    attributes.autocomplete = config.autocomplete
  }

  attributes.required = config.required
```

#### 3. Field Manager Definitions (`field-manager.js`)

**Before:**
```javascript
    name: 'EMAIL',
    title: i18n.emailAddress,
    required: true,
    forceRequired: true,
    type: 'email'
  }, true)
```

**After:**
```javascript
    name: 'EMAIL',
    title: i18n.emailAddress,
    required: true,
    forceRequired: true,
    type: 'email',
    autocomplete: 'email' // ✅ Default autofill type
  }, true)
```

## 🧪 Testing Performed

### Manual Testing
-   **Code Review**: Verified that the attribute is correctly passed from definition to generation.
-   **Default Form Verification**: Validated that `config/default-form-content.php` contains the correct HTML attribute.
-   **Build Verification**: Ran `npm run build` to ensure assets compile correctly.

## ⚠️ Breaking Changes
✅ **No breaking changes** - Fully backward compatible. Existing forms will remain unchanged until updated by the user.

### Plugin Zip

[mailchimp-for-wordpress-en777.zip](https://github.com/user-attachments/files/25319799/mailchimp-for-wordpress-en777.zip)


## ✅ PR Checklist
-   [x] Code follows WordPress Coding Standards
-   [x] Input sanitized, output escaped
-   [x] No PHP warnings/errors
-   [x] Backward compatible
-   [x] Self-reviewed for quality