### PR TITLE
feat(integration): add Simple Basic Contact Form integration

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -68,6 +68,7 @@ spl_autoload_register(function ($class) {
         'MC4WP_Queue' => '/includes/class-queue.php',
         'MC4WP_Queue_Job' => '/includes/class-queue-job.php',
         'MC4WP_Registration_Form_Integration' => '/integrations/wp-registration-form/class-registration-form.php',
+        'MC4WP_Simple_Basic_Contact_Form_Integration' => '/integrations/simple-basic-contact-form/class-simple-basic-contact-form.php',
         'MC4WP_Tools' => '/includes/class-tools.php',
         'MC4WP_Upgrade_Routines' => '/includes/admin/class-upgrade-routines.php',
         'MC4WP_User_Integration' => '/includes/integrations/class-user-integration.php',

--- a/integrations/bootstrap.php
+++ b/integrations/bootstrap.php
@@ -43,6 +43,7 @@ mc4wp_register_integration('events-manager', 'MC4WP_Events_Manager_Integration')
 mc4wp_register_integration('memberpress', 'MC4WP_MemberPress_Integration');
 mc4wp_register_integration('affiliatewp', 'MC4WP_AffiliateWP_Integration');
 mc4wp_register_integration('give', 'MC4WP_Give_Integration');
+mc4wp_register_integration('simple-basic-contact-form', 'MC4WP_Simple_Basic_Contact_Form_Integration');
 mc4wp_register_integration('custom', 'MC4WP_Custom_Integration', true);
 mc4wp_register_integration('woocommerce', 'MC4WP_WooCommerce_Integration');
 

--- a/integrations/simple-basic-contact-form/class-simple-basic-contact-form.php
+++ b/integrations/simple-basic-contact-form/class-simple-basic-contact-form.php
@@ -1,0 +1,117 @@
+<?php
+
+defined('ABSPATH') or exit;
+
+/**
+ * Class MC4WP_Simple_Basic_Contact_Form_Integration
+ *
+ * Integrates Mailchimp for WordPress with the Simple Basic Contact Form plugin.
+ *
+ * @since 4.9.0
+ * @ignore
+ */
+class MC4WP_Simple_Basic_Contact_Form_Integration extends MC4WP_Integration
+{
+    /**
+     * @var string
+     */
+    public $name = 'Simple Basic Contact Form';
+
+    /**
+     * @var string
+     */
+    public $description = 'Subscribes people from Simple Basic Contact Form forms.';
+
+    /**
+     * Add hooks
+     */
+    public function add_hooks()
+    {
+        add_filter('scf_filter_contact_form', [ $this, 'add_checkbox' ], 20);
+        add_action('scf_send_email', [ $this, 'process' ], 10, 5);
+    }
+
+    /**
+     * Adds the MC4WP checkbox to the Simple Basic Contact Form HTML.
+     *
+     * Inserts the checkbox before the closing </form> tag so it appears
+     * inside the form, just before the submit area.
+     *
+     * @param string $form_html The full contact form HTML.
+     * @return string Modified form HTML with the checkbox injected.
+     */
+    public function add_checkbox($form_html)
+    {
+        // do not add a checkbox when integration is implicit
+        if ($this->options['implicit']) {
+            return $form_html;
+        }
+
+        $checkbox_html = $this->get_checkbox_html();
+
+        // insert the checkbox just before the closing </form> tag
+        $form_html = str_ireplace('</form>', $checkbox_html . '</form>', $form_html);
+
+        return $form_html;
+    }
+
+    /**
+     * Process the form submission and subscribe the user if the checkbox was checked.
+     *
+     * Fires on the `scf_send_email` action after the contact form email is sent.
+     *
+     * @param string $recipient The email recipient.
+     * @param string $topic     The email subject.
+     * @param string $message   The email message body.
+     * @param string $headers   The email headers.
+     * @param string $email     The sender's email address (form submitter).
+     *
+     * @return bool
+     */
+    public function process($recipient, $topic, $message, $headers, $email)
+    {
+        // was sign-up checkbox checked?
+        if (! $this->triggered()) {
+            return false;
+        }
+
+        $parser = new MC4WP_Field_Guesser($this->get_data());
+        $data   = $parser->combine([ 'guessed', 'namespaced' ]);
+
+        // use the email from the action parameter if not found via field guesser
+        if (empty($data['EMAIL']) && ! empty($email)) {
+            $data['EMAIL'] = $email;
+        }
+
+        // do nothing if no email was found
+        if (empty($data['EMAIL'])) {
+            $this->get_log()->warning(sprintf('%s > Unable to find EMAIL field.', $this->name));
+            return false;
+        }
+
+        return $this->subscribe($data);
+    }
+
+    /**
+     * Are the required dependencies for this integration installed?
+     *
+     * @return bool
+     */
+    public function is_installed()
+    {
+        return function_exists('simple_contact_form');
+    }
+
+    /**
+     * Returns the UI elements to show on the settings page.
+     *
+     * Removes 'implicit' since this integration uses an explicit checkbox approach.
+     *
+     * @since 4.9.0
+     * @return array
+     */
+    public function get_ui_elements()
+    {
+        return array_diff(parent::get_ui_elements(), [ 'implicit' ]);
+    }
+}


### PR DESCRIPTION
## 🎯 Summary

Adds a new integration with the [Simple Basic Contact Form](https://wordpress.org/plugins/simple-basic-contact-form/) plugin, allowing users to subscribe to Mailchimp lists via an opt-in checkbox on SBCF contact forms.

## 📋 Issue Reference

Fixes #753

As [requested on WordPress.org support](https://wordpress.org/support/topic/simple-basic-contact-form-integration/).

## 🔍 Problem Description

### Current Behavior
The Simple Basic Contact Form plugin has no Mailchimp integration. Users who rely on SBCF for their contact forms cannot offer Mailchimp newsletter subscriptions through those forms.

### Expected Behavior
An opt-in checkbox should appear inside the Simple Basic Contact Form, and when checked, the form submitter's data should be sent to the selected Mailchimp list.

## ✨ Solution Overview

### Approach Taken
Created a new `MC4WP_Simple_Basic_Contact_Form_Integration` class that follows the **exact same pattern** used by the existing CF7 and Comment Form integrations. The integration hooks into two SBCF extension points:

1. **`scf_filter_contact_form`** (filter) — Injects the MC4WP checkbox HTML into the form before the `</form>` closing tag
2. **`scf_send_email`** (action) — Processes the subscription after the contact form email is successfully sent

### Why This Approach

- **Proven pattern**: Mirrors the existing CF7 integration architecture, which handles the same use case (third-party form → checkbox → subscribe)
- **Stable hooks**: Both `scf_filter_contact_form` and `scf_send_email` are well-established hooks in the SBCF plugin
- **Non-invasive**: The form's original behavior is completely unaffected — the checkbox is only added visually and subscription only triggers when explicitly checked
- **Field guessing**: Uses `MC4WP_Field_Guesser` on `$_POST` data (same as CF7) to automatically map form fields to Mailchimp merge fields

### Alternatives Considered

1. **Using `scf_custom_fields` hook**: Only suitable for adding extra form fields, not for injecting a checkbox with custom behavior. Would require more complex HTML manipulation.
2. **Output buffering approach**: Fragile and could interfere with other plugins. The `scf_filter_contact_form` filter is the intended extension point for modifying form HTML.

## 🔧 Changes Made

### Files Modified

| File | Change |
|---|---|
| `integrations/simple-basic-contact-form/class-simple-basic-contact-form.php` | **[NEW]** Integration class |
| `autoload.php` | Added classmap entry for new class |
| `integrations/bootstrap.php` | Registered integration with `mc4wp_register_integration()` |

### Detailed Changes

#### 1. Integration Class (New File)

```php
class MC4WP_Simple_Basic_Contact_Form_Integration extends MC4WP_Integration
```

**Key methods:**

| Method | Purpose |
|---|---|
| `add_hooks()` | Registers `scf_filter_contact_form` filter and `scf_send_email` action |
| `add_checkbox($form_html)` | Injects checkbox HTML before `</form>` using `str_ireplace()` |
| `process($recipient, $topic, $message, $headers, $email)` | Checks if checkbox was ticked, uses `MC4WP_Field_Guesser` to extract data, falls back to the `$email` action parameter if EMAIL not found via guesser |
| `is_installed()` | Returns `function_exists('simple_contact_form')` |
| `get_ui_elements()` | Removes `'implicit'` — explicit checkbox only (same as CF7) |

**Why this works:**

The `scf_send_email` action fires at [line 674 of the SBCF plugin](https://plugins.trac.wordpress.org/browser/simple-basic-contact-form/trunk/simple-basic-contact-form.php) **after** successful form validation and email delivery. This ensures:
- The subscription only happens when form submission succeeds
- The sender's `$email` is available as a reliable fallback
- All `$_POST` data is still accessible for field guessing

#### 2. Autoload Registration

```diff
 'MC4WP_Registration_Form_Integration' => '/integrations/wp-registration-form/class-registration-form.php',
+'MC4WP_Simple_Basic_Contact_Form_Integration' => '/integrations/simple-basic-contact-form/class-simple-basic-contact-form.php',
 'MC4WP_Tools' => '/includes/class-tools.php',
```

#### 3. Bootstrap Registration

```diff
 mc4wp_register_integration('give', 'MC4WP_Give_Integration');
+mc4wp_register_integration('simple-basic-contact-form', 'MC4WP_Simple_Basic_Contact_Form_Integration');
 mc4wp_register_integration('custom', 'MC4WP_Custom_Integration', true);
```

## 🧪 Testing Performed

### Automated Testing

```bash
$ vendor/bin/phpunit
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

......................................................            54 / 54 (100%)

Time: 00:00.021, Memory: 6.00 MB

OK (54 tests, 175 assertions)
```

✅ All 54 existing tests pass with 175 assertions — no regressions.

### Manual Testing

#### Test Case 1: Integration Visibility
**Steps:**
1. Activate both MC4WP and Simple Basic Contact Form plugins
2. Navigate to **Mailchimp for WP → Integrations**

**Expected:** "Simple Basic Contact Form" appears in the integrations list
**Actual:** ✅ Integration visible with correct name and description

#### Test Case 2: Checkbox Rendering
**Steps:**
1. Configure the SBCF integration (select list, set label)
2. Visit a page with the `[simple_contact_form]` shortcode

**Expected:** MC4WP checkbox appears inside the form, before submit
**Actual:** ✅ Checkbox renders correctly within the form

#### Test Case 3: Subscription Flow
**Steps:**
1. Fill out the contact form with valid data
2. Check the MC4WP checkbox
3. Submit the form

**Expected:** Email is added to the selected Mailchimp list
**Actual:** ✅ Subscription processed successfully

#### Test Case 4: Opt-out Respected
**Steps:**
1. Fill out the contact form
2. Leave the MC4WP checkbox unchecked
3. Submit the form

**Expected:** No Mailchimp subscription happens
**Actual:** ✅ No subscription — form email sent normally

## 📊 Performance Impact

**Analysis:** ✅ Negligible impact

- **No additional database queries** — Integration uses the same options loading mechanism as all existing integrations
- **No external API calls unless checkbox is checked** — The Mailchimp API is only contacted when the user explicitly opts in
- **Filter/action hooks are lightweight** — `str_ireplace()` for checkbox injection and `$_POST` reading for field guessing are trivial operations

## 🔒 Security Considerations

- ✅ **Input sanitization**: All user data is processed through `MC4WP_Field_Guesser`, which handles sanitization
- ✅ **Checkbox verification**: Uses `$this->triggered()` from the base class, which properly checks for the checkbox value
- ✅ **No direct database access**: All data flows through the existing MC4WP subscription pipeline
- ✅ **Email validation**: Handled by the base `MC4WP_Integration::subscribe()` method

## ♿ Accessibility

- ✅ Checkbox HTML is generated by `$this->get_checkbox_html()` from the base class, which follows the same accessible markup pattern used across all other integrations

## 🌍 Internationalization

- ✅ `$name` and `$description` follow the same pattern as existing integrations (English strings, consistent with codebase convention)
- ✅ Checkbox label is user-configurable through the admin UI

## ⚠️ Breaking Changes

✅ **No breaking changes** — This is a purely additive feature. Existing integrations and functionality are completely unaffected.

## Screenshots
<img width="2962" height="816" alt="CleanShot 2026-02-16 at 22 52 28@2x" src="https://github.com/user-attachments/assets/93b4a354-fc4b-4cc3-9882-130074a79c0b" />
<img width="1520" height="884" alt="CleanShot 2026-02-16 at 22 52 17@2x" src="https://github.com/user-attachments/assets/f8debd8d-c53a-4f6f-ba1c-be8b7f5c4b1a" />

### Plugin build/zip
[mailchimp-for-wp-fix-issue-753.zip](https://github.com/user-attachments/files/25346330/mailchimp-for-wp-fix-issue-753.zip)

## ✅ PR Checklist

- [x] Code follows WordPress Coding Standards
- [x] All functions have proper PHPDoc blocks
- [x] Follows existing integration patterns (CF7, Comment Form)
- [x] No PHP warnings/errors
- [x] Backward compatible — purely additive
- [x] Tests pass successfully (54 tests, 175 assertions)
- [x] Self-reviewed for quality

---

**Ready for Review** ✨