### PR TITLE
Fix: Required validation for Ninja Forms integration

### DIFF
--- a/integrations/ninja-forms/class-field.php
+++ b/integrations/ninja-forms/class-field.php
@@ -63,6 +63,30 @@ class MC4WP_Ninja_Forms_Field extends NF_Abstracts_Input
     }
 
     /**
+     * Validate the field value.
+     *
+     * Overrides parent to handle checkbox-specific required validation,
+     * since checkboxes submit '0' when unchecked which the parent considers valid.
+     *
+     * @since 4.9
+     *
+     * @param array $field The field data.
+     * @param array $data  The form data.
+     * @return array Array of validation errors, empty if valid.
+     */
+    public function validate($field, $data)
+    {
+        $errors = parent::validate($field, $data);
+
+        if (isset($field['required']) && 1 == intval($field['required']) && empty($field['value'])) {
+            $errors['slug']    = 'required-error';
+            $errors['message'] = esc_html__('This field is required.', 'mailchimp-for-wp');
+        }
+
+        return $errors;
+    }
+
+    /**
     * Custom Columns
     * Creates what is displayed in the columns on the submissions page.
     * @since 3.0

--- a/tests/NinjaFormsValidationTest.php
+++ b/tests/NinjaFormsValidationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
+
+// Mock WP functions
+if (! function_exists('add_filter')) {
+    function add_filter()
+    {
+    }
+}
+
+if (! function_exists('add_action')) {
+    function add_action()
+    {
+    }
+}
+
+if (! function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+if (! function_exists('esc_html__')) {
+    function esc_html__($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
+
+// Mock Parent Class
+if (! class_exists('NF_Abstracts_Input')) {
+    abstract class NF_Abstracts_Input
+    {
+        protected $_settings = []; // Needed for child constructor access
+
+        public function __construct()
+        {
+            // Mock constructor
+        }
+
+        public function validate($field, $data)
+        {
+            return [];
+        }
+    }
+}
+
+require_once __DIR__ . '/../integrations/ninja-forms/class-field.php';
+
+class NinjaFormsValidationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRequiredValidationFailsOnEmpty()
+    {
+        $field = new MC4WP_Ninja_Forms_Field();
+
+        $field_data = [
+            'required' => 1,
+            'value' => 0,
+        ];
+        $form_data = [];
+
+        $errors = $field->validate($field_data, $form_data);
+
+        $this->assertIsArray($errors);
+        $this->assertArrayHasKey('slug', $errors, 'Error slug should be present');
+        $this->assertEquals('required-error', $errors['slug']);
+    }
+
+    public function testRequiredValidationPassesOnChecked()
+    {
+        $field = new MC4WP_Ninja_Forms_Field();
+
+        $field_data = [
+            'required' => 1,
+            'value' => 1,
+        ];
+        $form_data = [];
+
+        $errors = $field->validate($field_data, $form_data);
+
+        $this->assertEmpty($errors, 'Validation should pass for required checked field');
+    }
+
+    public function testOptionalValidationPassesOnUnchecked()
+    {
+        $field = new MC4WP_Ninja_Forms_Field();
+
+        $field_data = [
+            'required' => 0,
+            'value' => 0,
+        ];
+        $form_data = [];
+
+        $errors = $field->validate($field_data, $form_data);
+
+        $this->assertEmpty($errors, 'Validation should pass for optional unchecked field');
+    }
+}


### PR DESCRIPTION
## 🎯 Summary

Fixes an issue where the "Mailchimp opt-in" field in Ninja Forms would not prevent form submission when marked as "Required" but left unchecked. This PR implements strict validation logic for the checkbox field.

## 📋 Issue Reference

Fixes #717

## 🔍 Problem Description

### Current Behavior
In Ninja Forms, when the "Mailchimp for WordPress" checkbox field is added to a form and the "Required" toggle is enabled, users can still submit the form without checking the box. This happens because Ninja Forms treats an unchecked checkbox (value `0`) as a valid submission unless specific validation logic overrides it.

### Expected Behavior
If the field is marked as "Required", the form submission should be blocked with an error message ("This field is required") if the checkbox is not checked.

### Root Cause
The `MC4WP_Ninja_Forms_Field` class extends `NF_Abstracts_Input` but did not implement a custom `validate()` method to handle the specific behavior of unchecked checkboxes (which submit a value of `0`, passing the default empty check in some contexts or failing to trigger the required error correctly).

## ✨ Solution Overview

### Approach Taken
I implemented a `validate()` method in `MC4WP_Ninja_Forms_Field` that strictly checks:
1. If the field is marked as `required`.
2. If the submitted value is empty or `0`.

If both are true, it returns a validation error.

### Why This Approach
This leverages Ninja Forms' native validation pipeline. By overriding the `validate` method in the field class itself, we ensure the rule is enforced consistently whenever the field is used, without relying on fragile frontend JavaScript or external hooks.

## 🔧 Changes Made

### Files Modified
- `integrations/ninja-forms/class-field.php` - Added `validate()` method to enforce required state.
- `tests/NinjaFormsValidationTest.php` - (New) Added unit tests to verify usage.

### Detailed Changes

#### 1. `integrations/ninja-forms/class-field.php`

**Before:**
No `validate()` method existed; it relied on the parent class which didn't handle the `0` value correctly for this specific required context.

**After:**
```php
public function validate($field, $data)
{
    $errors = parent::validate($field, $data);

    if (isset($field['required']) && 1 == intval($field['required']) && empty($field['value'])) {
        $errors['slug']    = 'required-error';
        $errors['message'] = esc_html__('This field is required.', 'mailchimp-for-wp');
    }

    return $errors;
}
```

**Why This Works:**
It explicitly checks the `required` flag and the `value`. Since unchecked checkboxes submit `0` or empty string, `empty($field['value'])` correctly identifies the invalid state.

## 🧪 Testing Performed

### Test Environment
- WordPress Version: 6.6.1
- PHP Version: 8.1
- Ninja Forms: Latest
- Mailchimp for WordPress: Local build from feature branch

### Manual Testing

#### Test Case 1: Required Field Validation
**Steps:**
1. Add "Mailchimp opt-in" field to a Ninja Form.
2. Enable "Required" setting.
3. Submit form without checking the box.

**Expected Result:** Validation error "This field is required" appears.
**Actual Result:** ✅ Validation error appeared and submission was blocked.

#### Test Case 2: Successful Submission
**Steps:**
1. Check the "Mailchimp opt-in" box.
2. Submit form.

**Expected Result:** Form submits successfully.
**Actual Result:** ✅ Form submitted.

### Automated Testing

```bash
$ ./vendor/bin/phpunit tests/NinjaFormsValidationTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

...                                                                 3 / 3 (100%)

Time: 00:00.004, Memory: 6.00 MB

OK (3 tests, 5 assertions)
```

**Test Coverage:**
- ✅ Validates required field fails when empty/0.
- ✅ Validates required field passes when checked (1).
- ✅ Validates optional field passes when unchecked (0).

## ⚠️ Breaking Changes
✅ **No breaking changes**

## Screen recording
![Screen recording](https://github.com/user-attachments/assets/3f03f04a-b9ee-4045-912c-c970e4d2e1f2)

### Plugin build/zip

[Uploading mailchimp-for-wp-issue-717.zip…]()

## 📚 Documentation Updates
- N/A

## ✅ PR Checklist
- [x] Code follows WordPress Coding Standards
- [x] All functions have proper PHPDoc blocks
- [x] Input sanitized, output escaped
- [x] Strings are translatable
- [x] Tests pass successfully
- [x] Self-reviewed for quality