### PR TITLE
feat(integrations): add PeepSo registration form integration

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -62,6 +62,7 @@ spl_autoload_register(function ($class) {
         'MC4WP_Ninja_Forms_Field' => '/integrations/ninja-forms/class-field.php',
         'MC4WP_Ninja_Forms_Integration' => '/integrations/ninja-forms/class-ninja-forms.php',
         'MC4WP_Ninja_Forms_V2_Integration' => '/integrations/ninja-forms-2/class-ninja-forms.php',
+        'MC4WP_PeepSo_Integration' => '/integrations/peepso/class-peepso.php',
         'MC4WP_Plugin' => '/includes/class-plugin.php',
         'MC4WP_Procaptcha_Integration' => '/integrations/prosopo-procaptcha/class-procaptcha-integration.php',
         'MC4WP_Procaptcha' => '/integrations/prosopo-procaptcha/class-procaptcha.php',

--- a/integrations/bootstrap.php
+++ b/integrations/bootstrap.php
@@ -41,6 +41,7 @@ mc4wp_register_integration('easy-digital-downloads', 'MC4WP_Easy_Digital_Downloa
 mc4wp_register_integration('contact-form-7', 'MC4WP_Contact_Form_7_Integration', true);
 mc4wp_register_integration('events-manager', 'MC4WP_Events_Manager_Integration');
 mc4wp_register_integration('memberpress', 'MC4WP_MemberPress_Integration');
+mc4wp_register_integration('peepso', 'MC4WP_PeepSo_Integration');
 mc4wp_register_integration('affiliatewp', 'MC4WP_AffiliateWP_Integration');
 mc4wp_register_integration('give', 'MC4WP_Give_Integration');
 mc4wp_register_integration('custom', 'MC4WP_Custom_Integration', true);

--- a/integrations/peepso/class-peepso.php
+++ b/integrations/peepso/class-peepso.php
@@ -1,0 +1,65 @@
+<?php
+
+defined('ABSPATH') or exit;
+
+/**
+ * Class MC4WP_PeepSo_Integration
+ *
+ * @ignore
+ */
+class MC4WP_PeepSo_Integration extends MC4WP_User_Integration
+{
+    /**
+     * @var string
+     */
+    public $name = 'PeepSo';
+
+    /**
+     * @var string
+     */
+    public $description = 'Subscribes users from PeepSo registration forms.';
+
+    /**
+     * Add hooks
+     */
+    public function add_hooks()
+    {
+        if (! $this->options['implicit']) {
+            add_action('peepso_register_extended_fields', [ $this, 'output_checkbox' ], 20);
+        }
+
+        add_action('peepso_register_new_user', [ $this, 'subscribe_from_peepso' ], 10, 1);
+    }
+
+    /**
+     * Subscribes from PeepSo Registration Form.
+     *
+     * @param int $user_id
+     * @return bool
+     */
+    public function subscribe_from_peepso($user_id)
+    {
+        if (! $this->triggered()) {
+            return false;
+        }
+
+        $user = get_userdata($user_id);
+
+        // was a user found with the given ID?
+        if (! $user instanceof WP_User) {
+            return false;
+        }
+
+        $data = $this->user_merge_vars($user);
+
+        return $this->subscribe($data, $user_id);
+    }
+
+    /**
+     * @return bool
+     */
+    public function is_installed()
+    {
+        return class_exists('PeepSo');
+    }
+}


### PR DESCRIPTION
## 🎯 Summary

Adds a new PeepSo registration form integration that allows users to subscribe to Mailchimp lists when registering through PeepSo's `[peepso_register]` shortcode form.

## 📋 Issue Reference

Fixes #696

## 🔍 Problem Description

### Current Behavior
Mailchimp for WordPress does not integrate with PeepSo's registration form. Users who register through PeepSo cannot opt-in to Mailchimp email lists during the registration process.

### Expected Behavior
A "Subscribe to our newsletter" checkbox should appear in the PeepSo registration form, and checking it should subscribe the user to the configured Mailchimp list upon successful registration.

### Root Cause
No integration class exists for PeepSo. The plugin needs a dedicated integration that hooks into PeepSo's registration hooks to output the checkbox and process the subscription.

## ✨ Solution Overview

### Approach Taken
Created a new `MC4WP_PeepSo_Integration` class extending `MC4WP_User_Integration` (the same base class used by the BuddyPress integration). This follows the established pattern used by all other user-based integrations in the plugin.

The integration hooks into two PeepSo actions:
| Hook | Purpose |
|------|---------|
| `peepso_register_extended_fields` | Renders the Mailchimp opt-in checkbox in the registration form |
| `peepso_register_new_user` | Processes the subscription after user creation |

### Why This Approach
- **Consistency**: Follows the exact same pattern as the existing BuddyPress integration (`MC4WP_BuddyPress_Integration`), which also extends `MC4WP_User_Integration`
- **Minimal footprint**: Only 65 lines of code — leverages all inherited functionality from `MC4WP_User_Integration` and `MC4WP_Integration`
- **Battle-tested pattern**: Uses the same `triggered()` → `user_merge_vars()` → `subscribe()` flow proven by other integrations

### Alternatives Considered
1. **Hooking `peepso_register_verified` instead of `peepso_register_new_user`**: Would delay subscription until email verification (if enabled). Not chosen because other integrations subscribe at user creation time, and the Mailchimp API handles double opt-in separately.
2. **Using `peepso_register_form_fields` filter**: Would inject the checkbox as a PeepSo form field. Not chosen because it would couple the implementation to PeepSo's form rendering internals, whereas `peepso_register_extended_fields` is the designated hook for third-party additions.

## 🔧 Changes Made

### Files Modified
- `integrations/peepso/class-peepso.php` - **[NEW]** PeepSo integration class
- `autoload.php` - Added classmap entry for the new class
- `integrations/bootstrap.php` - Registered the integration

### Detailed Changes

#### 1. New File: `integrations/peepso/class-peepso.php`

```php
class MC4WP_PeepSo_Integration extends MC4WP_User_Integration
{
    public $name = 'PeepSo';
    public $description = 'Subscribes users from PeepSo registration forms.';

    public function add_hooks()
    {
        if (! $this->options['implicit']) {
            add_action('peepso_register_extended_fields', [ $this, 'output_checkbox' ], 20);
        }
        add_action('peepso_register_new_user', [ $this, 'subscribe_from_peepso' ], 10, 1);
    }

    public function subscribe_from_peepso($user_id)
    {
        if (! $this->triggered()) {
            return false;
        }
        $user = get_userdata($user_id);
        if (! $user instanceof WP_User) {
            return false;
        }
        $data = $this->user_merge_vars($user);
        return $this->subscribe($data, $user_id);
    }

    public function is_installed()
    {
        return class_exists('PeepSo');
    }
}
```

**Why This Works:**
- `peepso_register_extended_fields` fires inside the registration form, after the standard fields, which is the designated hook point for third-party field additions
- `peepso_register_new_user` fires after successful user creation and passes the `$user_id`
- `triggered()` checks whether the checkbox was checked (or implicit mode is enabled)
- `user_merge_vars()` extracts the user's email, first name, and last name from `WP_User`
- `subscribe()` handles the Mailchimp API call with all configured options

**Impact:**
- ✅ PeepSo registration form gets opt-in checkbox support
- ✅ Implicit mode (auto-subscribe without checkbox) works out of the box
- ✅ All existing integration admin UI (list selection, double opt-in toggle, etc.) works automatically via inheritance

#### 2. `autoload.php`

```diff
  'MC4WP_Ninja_Forms_V2_Integration' => '/integrations/ninja-forms-2/class-ninja-forms.php',
+ 'MC4WP_PeepSo_Integration' => '/integrations/peepso/class-peepso.php',
  'MC4WP_Plugin' => '/includes/class-plugin.php',
```

#### 3. `integrations/bootstrap.php`

```diff
  mc4wp_register_integration('memberpress', 'MC4WP_MemberPress_Integration');
+ mc4wp_register_integration('peepso', 'MC4WP_PeepSo_Integration');
  mc4wp_register_integration('affiliatewp', 'MC4WP_AffiliateWP_Integration');
```

## 🧪 Testing Performed

### Automated Testing

```bash
$ vendor/bin/phpunit
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

......................................................            54 / 54 (100%)

Time: 00:00.021, Memory: 6.00 MB

OK (54 tests, 175 assertions)
```

✅ All **54 existing tests pass** with 175 assertions — zero regressions.

### Manual Testing

#### Test Case 1: Integration Appears in Admin
**Steps:**
1. Activate plugin with PeepSo installed
2. Navigate to **Mailchimp for WP → Integrations**

**Expected Result:** "PeepSo" appears in the integrations list

**Actual Result:** ✅ PeepSo integration is listed and configurable

#### Test Case 2: Integration Shows "Not Installed" Without PeepSo
**Steps:**
1. Deactivate PeepSo
2. Navigate to **Mailchimp for WP → Integrations**

**Expected Result:** PeepSo integration shows as not installed

**Actual Result:** ✅ `is_installed()` correctly returns `false` when PeepSo class doesn't exist

## 🔒 Security Considerations

- ✅ No direct user input handling — all data flows through existing `MC4WP_User_Integration` methods
- ✅ User data retrieved via WordPress core `get_userdata()` function
- ✅ Subscription checked via `triggered()` which uses `sanitize_text_field` internally
- ✅ No database queries — uses WordPress user API exclusively
- ✅ No output escaping needed — checkbox output handled by parent class `output_checkbox()`

## ♿ Accessibility

- ✅ Checkbox output inherits accessibility attributes from parent `MC4WP_Integration::output_checkbox()` method
- ✅ Label text is configurable and translatable via the admin UI

## 🌍 Internationalization

- ✅ Integration name and description are used in admin context only
- ✅ User-facing checkbox label is configurable through the admin UI (uses the plugin's existing i18n system)

## ⚠️ Breaking Changes

✅ **No breaking changes** — This is a purely additive feature. Existing integrations and functionality are completely unaffected.

## Screenshots

<img width="3680" height="2382" alt="Backend" src="https://github.com/user-attachments/assets/0308e058-1657-4773-a70a-16800f14851e" />
<img width="3680" height="2382" alt="Frontend" src="https://github.com/user-attachments/assets/b339572a-94b2-42b0-aa6e-28a2bbbe35b2" />

## ✅ PR Checklist

- [x] Code follows WordPress Coding Standards
- [x] All functions have proper PHPDoc blocks
- [x] No direct user input — data flows through existing sanitized methods
- [x] Backward compatible — purely additive change
- [x] Tests pass successfully (54/54)
- [x] Self-reviewed for quality
- [x] Follows established integration patterns (mirrors BuddyPress integration)

## 🤝 Additional Context

- The integration class structure mirrors [`MC4WP_BuddyPress_Integration`](https://github.com/ibericode/mailchimp-for-wordpress/blob/main/integrations/buddypress/class-buddypress.php) almost exactly, ensuring consistency across the codebase
- PeepSo hooks were identified from the PeepSo core plugin source (`classes/register.php` lines 2906-2910)
- The `peepso_register_extended_fields` hook is the officially recommended extension point for third-party registration fields in PeepSo