### PR TITLE
fix: show WP-Cron behind schedule warning notice

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -16,6 +16,7 @@ spl_autoload_register(function ($class) {
         'MC4WP_Admin' => '/includes/admin/class-admin.php',
         'MC4WP_Admin_Ads' => '/includes/admin/class-ads.php',
         'MC4WP_Admin_Ajax' => '/includes/admin/class-admin-ajax.php',
+        'MC4WP_Admin_Cron_Notice' => '/includes/admin/class-cron-notice.php',
         'MC4WP_Admin_Messages' => '/includes/admin/class-admin-messages.php',
         'MC4WP_Admin_Review_Notice' => '/includes/admin/class-review-notice.php',
         'MC4WP_Admin_Texts' => '/includes/admin/class-admin-texts.php',

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -34,6 +34,11 @@ class MC4WP_Admin
     protected $review_notice;
 
     /**
+     * @var MC4WP_Admin_Cron_Notice
+     */
+    protected $cron_notice;
+
+    /**
      * Constructor
      *
      * @param MC4WP_Admin_Tools $tools
@@ -46,6 +51,7 @@ class MC4WP_Admin
         $this->plugin_file   = plugin_basename(MC4WP_PLUGIN_FILE);
         $this->ads           = new MC4WP_Admin_Ads();
         $this->review_notice = new MC4WP_Admin_Review_Notice($tools);
+        $this->cron_notice   = new MC4WP_Admin_Cron_Notice($tools);
     }
 
     /**
@@ -70,6 +76,7 @@ class MC4WP_Admin
         $this->ads->add_hooks();
         $this->messages->add_hooks();
         $this->review_notice->add_hooks();
+        $this->cron_notice->add_hooks();
     }
 
     /**

--- a/includes/admin/class-cron-notice.php
+++ b/includes/admin/class-cron-notice.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Class MC4WP_Admin_Cron_Notice
+ *
+ * Shows a warning notice when WP-Cron is more than one hour behind schedule.
+ *
+ * @since 4.13.0
+ * @ignore
+ */
+class MC4WP_Admin_Cron_Notice
+{
+    /**
+     * @var MC4WP_Admin_Tools
+     */
+    protected $tools;
+
+    /**
+     * @var string
+     */
+    protected $meta_key_dismissed = '_mc4wp_cron_notice_dismissed';
+
+    /**
+     * MC4WP_Admin_Cron_Notice constructor.
+     *
+     * @since 4.13.0
+     * @param MC4WP_Admin_Tools $tools
+     */
+    public function __construct(MC4WP_Admin_Tools $tools)
+    {
+        $this->tools = $tools;
+    }
+
+    /**
+     * Add action & filter hooks.
+     *
+     * @since 4.13.0
+     */
+    public function add_hooks(): void
+    {
+        add_action('admin_notices', [ $this, 'show' ]);
+        add_action('mc4wp_admin_dismiss_cron_notice', [ $this, 'dismiss' ]);
+    }
+
+    /**
+     * Set flag in user meta so notice won't be shown again.
+     *
+     * @since 4.13.0
+     */
+    public function dismiss(): void
+    {
+        $user = wp_get_current_user();
+        update_user_meta($user->ID, $this->meta_key_dismissed, 1);
+    }
+
+    /**
+     * Show the cron warning notice if the scheduled event is behind.
+     *
+     * @since 4.13.0
+     */
+    public function show(): void
+    {
+        // only show on Mailchimp for WordPress' pages
+        if (! $this->tools->on_plugin_page()) {
+            return;
+        }
+
+        // only show to authorized users
+        if (! $this->tools->is_user_authorized()) {
+            return;
+        }
+
+        // only show if user did not dismiss before
+        $user = wp_get_current_user();
+        if (get_user_meta($user->ID, $this->meta_key_dismissed, true)) {
+            return;
+        }
+
+        // check if cron is behind schedule
+        if (! $this->is_cron_behind_schedule()) {
+            return;
+        }
+
+        echo '<div class="notice notice-warning mc4wp-is-dismissible">';
+        echo '<p>';
+        echo esc_html__('Heads up! The scheduled Mailchimp for WordPress cron event appears to be running behind schedule. This could mean WP-Cron is not functioning correctly on your site. Please check your site\'s cron configuration.', 'mailchimp-for-wp');
+        echo '</p>';
+        echo '<form method="POST">';
+        echo '<button type="submit" class="notice-dismiss"><span class="screen-reader-text">', esc_html__('Dismiss this notice.', 'mailchimp-for-wp'), '</span></button>';
+        echo '<input type="hidden" name="_mc4wp_action" value="dismiss_cron_notice" />';
+        wp_nonce_field('_mc4wp_action', '_wpnonce', true, true);
+        echo '</form>';
+        echo '</div>';
+    }
+
+    /**
+     * Check whether the plugin's cron event is more than one hour behind schedule.
+     *
+     * @since 4.13.0
+     * @return bool True if cron is behind schedule, false otherwise.
+     */
+    public function is_cron_behind_schedule(): bool
+    {
+        $next_scheduled = wp_next_scheduled('mc4wp_refresh_mailchimp_lists');
+
+        // no event scheduled at all — don't show warning for this edge case
+        // as the plugin may not have been activated via the normal flow
+        if ($next_scheduled === false) {
+            return false;
+        }
+
+        // if the next scheduled time is more than 1 hour in the past, cron is behind
+        return $next_scheduled < (time() - HOUR_IN_SECONDS);
+    }
+}

--- a/tests/CronNoticeTest.php
+++ b/tests/CronNoticeTest.php
@@ -1,0 +1,140 @@
+<?php
+
+class CronNoticeTest extends PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MC4WP_Admin_Cron_Notice
+     */
+    private $notice;
+
+    protected function setUp(): void
+    {
+        global $mock_wp_next_scheduled, $mock_current_user_can, $mock_user_meta;
+        $mock_wp_next_scheduled = false;
+        $mock_current_user_can  = true;
+        $mock_user_meta         = [];
+
+        // Use a partial mock of MC4WP_Admin_Tools to control on_plugin_page and is_user_authorized
+        $tools = $this->createPartialMock(MC4WP_Admin_Tools::class, ['on_plugin_page', 'is_user_authorized']);
+        $tools->method('on_plugin_page')->willReturn(true);
+        $tools->method('is_user_authorized')->willReturn(true);
+
+        $this->notice = new MC4WP_Admin_Cron_Notice($tools);
+    }
+
+    public function test_not_behind_schedule_when_no_event_scheduled(): void
+    {
+        global $mock_wp_next_scheduled;
+        $mock_wp_next_scheduled = false;
+
+        $this->assertFalse($this->notice->is_cron_behind_schedule());
+    }
+
+    public function test_not_behind_schedule_when_event_is_in_future(): void
+    {
+        global $mock_wp_next_scheduled;
+        $mock_wp_next_scheduled = time() + 3600;
+
+        $this->assertFalse($this->notice->is_cron_behind_schedule());
+    }
+
+    public function test_not_behind_schedule_when_event_is_slightly_past(): void
+    {
+        global $mock_wp_next_scheduled;
+        // 30 minutes ago — within the 1 hour threshold
+        $mock_wp_next_scheduled = time() - 1800;
+
+        $this->assertFalse($this->notice->is_cron_behind_schedule());
+    }
+
+    public function test_behind_schedule_when_event_is_over_one_hour_past(): void
+    {
+        global $mock_wp_next_scheduled;
+        // 2 hours ago — well past the threshold
+        $mock_wp_next_scheduled = time() - 7200;
+
+        $this->assertTrue($this->notice->is_cron_behind_schedule());
+    }
+
+    public function test_show_outputs_notice_when_behind_schedule(): void
+    {
+        global $mock_wp_next_scheduled;
+        $mock_wp_next_scheduled = time() - 7200;
+
+        ob_start();
+        $this->notice->show();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('notice-warning', $output);
+        $this->assertStringContainsString('dismiss_cron_notice', $output);
+    }
+
+    public function test_show_outputs_nothing_when_on_schedule(): void
+    {
+        global $mock_wp_next_scheduled;
+        $mock_wp_next_scheduled = time() + 3600;
+
+        ob_start();
+        $this->notice->show();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function test_show_outputs_nothing_when_dismissed(): void
+    {
+        global $mock_wp_next_scheduled, $mock_user_meta;
+        $mock_wp_next_scheduled   = time() - 7200;
+        $mock_user_meta['1:_mc4wp_cron_notice_dismissed'] = 1;
+
+        ob_start();
+        $this->notice->show();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function test_dismiss_sets_user_meta(): void
+    {
+        global $mock_user_meta;
+
+        $this->notice->dismiss();
+        $this->assertEquals(1, $mock_user_meta['1:_mc4wp_cron_notice_dismissed']);
+    }
+
+    public function test_show_outputs_nothing_when_not_on_plugin_page(): void
+    {
+        global $mock_wp_next_scheduled;
+        $mock_wp_next_scheduled = time() - 7200;
+
+        $tools = $this->createPartialMock(MC4WP_Admin_Tools::class, ['on_plugin_page', 'is_user_authorized']);
+        $tools->method('on_plugin_page')->willReturn(false);
+        $tools->method('is_user_authorized')->willReturn(true);
+
+        $notice = new MC4WP_Admin_Cron_Notice($tools);
+
+        ob_start();
+        $notice->show();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function test_show_outputs_nothing_when_user_not_authorized(): void
+    {
+        global $mock_wp_next_scheduled;
+        $mock_wp_next_scheduled = time() - 7200;
+
+        $tools = $this->createPartialMock(MC4WP_Admin_Tools::class, ['on_plugin_page', 'is_user_authorized']);
+        $tools->method('on_plugin_page')->willReturn(true);
+        $tools->method('is_user_authorized')->willReturn(false);
+
+        $notice = new MC4WP_Admin_Cron_Notice($tools);
+
+        ob_start();
+        $notice->show();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+}

--- a/tests/mock.php
+++ b/tests/mock.php
@@ -204,3 +204,84 @@ function shortcode_parse_atts($text)
     }
     return $atts;
 }
+
+/**
+ * @ignore
+ * @var int|false
+ */
+$mock_wp_next_scheduled = false;
+
+/** @ignore */
+function wp_next_scheduled($hook, $args = [])
+{
+    global $mock_wp_next_scheduled;
+    return $mock_wp_next_scheduled;
+}
+
+/**
+ * @ignore
+ * @var bool
+ */
+$mock_current_user_can = true;
+
+/** @ignore */
+function current_user_can($capability)
+{
+    global $mock_current_user_can;
+    return $mock_current_user_can;
+}
+
+/**
+ * @ignore
+ * @var array
+ */
+$mock_user_meta = [];
+
+/** @ignore */
+function get_user_meta($user_id, $key = '', $single = false)
+{
+    global $mock_user_meta;
+    $meta_key = $user_id . ':' . $key;
+    if (isset($mock_user_meta[$meta_key])) {
+        return $mock_user_meta[$meta_key];
+    }
+    return false;
+}
+
+/** @ignore */
+function update_user_meta($user_id, $meta_key, $meta_value)
+{
+    global $mock_user_meta;
+    $mock_user_meta[$user_id . ':' . $meta_key] = $meta_value;
+    return true;
+}
+
+/** @ignore */
+function wp_get_current_user()
+{
+    $user     = new stdClass();
+    $user->ID = 1;
+    return $user;
+}
+
+/** @ignore */
+function wp_nonce_field($action, $name, $referer = true, $display = true)
+{
+    $field = '<input type="hidden" name="' . $name . '" value="nonce" />';
+    if ($display) {
+        echo $field;
+    }
+    return $field;
+}
+
+/** @ignore */
+function wp_kses($content, $allowed_html, $allowed_protocols = [])
+{
+    return $content;
+}
+
+/** @ignore */
+function plugin_basename($file)
+{
+    return basename($file);
+}


### PR DESCRIPTION
## Summary

Adds an admin notice that warns users if the `mc4wp_refresh_mailchimp_lists` WP-Cron event is more than one hour behind schedule. This helps users quickly identify broken WP-Cron configurations (e.g., `DISABLE_WP_CRON` without a server cron) that cause background synchronizations to silently fail.

Fixes #826

## Problem

When a user's WP-Cron setup is not functioning correctly, essential background tasks like Mailchimp list synchronizations fail to run. Users are currently unaware when this happens until they notice data discrepancies.

## Solution

Implemented a dedicated `MC4WP_Admin_Cron_Notice` class that checks if the next scheduled run for the refresh event is >3600 seconds in the past. If true, it renders a standard, dismissible WordPress `notice-warning` strictly on the plugin's settings pages to alert authorized users.

## Changes

### includes/admin/class-cron-notice.php

**Before:**
(File did not exist)

**After:**
```php
public function is_cron_behind_schedule(): bool
{
    $next_scheduled = wp_next_scheduled('mc4wp_refresh_mailchimp_lists');

    if ($next_scheduled === false) {
        return false;
    }

    return $next_scheduled < (time() - HOUR_IN_SECONDS);
}
```

**Why:** Safely checks WP-Cron queues without triggering a database write. The threshold of 1 hour handles standard page-load delays while accurately catching completely disabled cron runners.

## Testing

**Test 1: Simulated Cron Failure**
- Steps: 1) Set `DISABLE_WP_CRON` to true 2) Mutate cron event schedule to 2 hours in the past via WP-CLI 3) Load `/wp-admin/admin.php?page=mailchimp-for-wp`
- Result: Works as expected. Notice renders properly and disappears upon dismissal.

**Test 2: Normal Operations**
- Steps: 1) Reset cron event to the future 2) Load admin page
- Result: Handled correctly. No notice displayed.

**Automated:**
```bash
$ composer run-script test
OK (72 tests, 201 assertions)
```

## Build

[mailchimp-for-wp-feature-826.zip](https://github.com/user-attachments/files/26148281/mailchimp-for-wp-feature-826.zip) built locally for development testing.
**Install:** WP Admin → Plugins → Upload

## Screenshot 

<img width="1916" height="928" alt="image" src="https://github.com/user-attachments/assets/e8d47a19-2d56-44e6-82d9-a2b9f233cf77" />
