### PR TITLE
feat: Add Mailchimp Campaign Archive block and shortcode (#811)

### DIFF
--- a/assets/src/js/campaigns-block.js
+++ b/assets/src/js/campaigns-block.js
@@ -1,0 +1,77 @@
+const __ = window.wp.i18n.__
+const { registerBlockType } = window.wp.blocks
+const { useBlockProps, InspectorControls } = window.wp.blockEditor
+const { PanelBody, RangeControl, SelectControl, ToggleControl } = window.wp.components
+
+registerBlockType('mailchimp-for-wp/campaigns', {
+  apiVersion: 3,
+  title: __('Mailchimp Campaign Archive'),
+  description: __('Block showing an archive of sent Mailchimp campaigns'),
+  category: 'widgets',
+  attributes: {
+    count: {
+      type: 'integer',
+      default: 10
+    },
+    title_type: {
+      type: 'string',
+      default: 'title'
+    },
+    show_date: {
+      type: 'boolean',
+      default: true
+    }
+  },
+  icon: (
+    <svg width="16" height="16" viewBox="0 0 16 16" version="1.1">
+      <path opacity="1" fill="#a0a5aa" fillOpacity="1" stroke="none" d="M 8.0097656 0.052734375 A 8 8 0 0 0 0.009765625 8.0527344 A 8 8 0 0 0 8.0097656 16.052734 A 8 8 0 0 0 16.009766 8.0527344 A 8 8 0 0 0 8.0097656 0.052734375 z M 9.2597656 4.171875 C 9.3205456 4.171875 9.9296146 5.0233822 10.611328 6.0664062 C 11.293041 7.1094313 12.296018 8.5331666 12.841797 9.2285156 L 13.833984 10.492188 L 13.316406 11.041016 C 13.031321 11.342334 12.708299 11.587891 12.599609 11.587891 C 12.253798 11.587891 11.266634 10.490156 10.349609 9.0859375 C 9.8610009 8.3377415 9.4126385 7.7229 9.3515625 7.71875 C 9.2904825 7.71455 9.2402344 8.3477011 9.2402344 9.1269531 L 9.2402344 10.544922 L 8.5839844 10.982422 C 8.2233854 11.223015 7.8735746 11.418294 7.8066406 11.417969 C 7.7397106 11.417644 7.4861075 10.997223 7.2421875 10.482422 C 6.9982675 9.9676199 6.6560079 9.3946444 6.4824219 9.2089844 L 6.1679688 8.8710938 L 6.0664062 9.34375 C 5.7203313 10.974656 5.6693219 11.090791 5.0917969 11.505859 C 4.5805569 11.873288 4.2347982 12.017623 4.1914062 11.882812 C 4.1839062 11.859632 4.1482681 11.574497 4.1113281 11.25 C 3.9708341 10.015897 3.5347399 8.7602861 2.8105469 7.5019531 C 2.5672129 7.0791451 2.5711235 7.0651693 2.9765625 6.8320312 C 3.2046215 6.7008903 3.5466561 6.4845105 3.7363281 6.3515625 C 4.0587811 6.1255455 4.1076376 6.1466348 4.4941406 6.6679688 C 4.8138896 7.0992628 4.9275606 7.166285 4.9941406 6.96875 C 5.0960956 6.666263 6.181165 5.8574219 6.484375 5.8574219 C 6.600668 5.8574219 6.8857635 6.1981904 7.1171875 6.6152344 C 7.3486105 7.0322784 7.5790294 7.3728809 7.6308594 7.3730469 C 7.7759584 7.3735219 7.9383234 5.8938023 7.8339844 5.5195312 C 7.7605544 5.2561423 7.8865035 5.0831575 8.4453125 4.6796875 C 8.8327545 4.3999485 9.1989846 4.171875 9.2597656 4.171875 z " />
+    </svg>
+  ),
+  supports: {
+    html: false
+  },
+
+  edit: function ({ attributes, setAttributes }) {
+    const titleTypeOptions = [
+      { label: __('Campaign title'), value: 'title' },
+      { label: __('Email subject line'), value: 'subject_line' }
+    ]
+
+    return (
+      <div>
+        <InspectorControls>
+          <PanelBody title={__('Settings')}>
+            <RangeControl
+              label={__('Number of campaigns')}
+              value={attributes.count}
+              onChange={(value) => setAttributes({ count: value })}
+              min={1}
+              max={100}
+            />
+            <SelectControl
+              label={__('Show label as')}
+              value={attributes.title_type}
+              options={titleTypeOptions}
+              onChange={(value) => setAttributes({ title_type: value })}
+            />
+            <ToggleControl
+              label={__('Show send date')}
+              checked={attributes.show_date}
+              onChange={(value) => setAttributes({ show_date: value })}
+            />
+          </PanelBody>
+        </InspectorControls>
+        <div style={{ backgroundColor: '#f8f9f9', padding: '14px' }} {...useBlockProps()}>
+          <p style={{ fontStyle: 'italic', color: '#777', margin: 0 }}>
+            {__('Mailchimp Campaign Archive — campaigns will appear here on the front end.')}
+          </p>
+        </div>
+      </div>
+    )
+  },
+
+  // Render nothing in the saved content, because we render in PHP.
+  save: function () {
+    return null
+  }
+})

--- a/assets/src/js/campaigns-block.js
+++ b/assets/src/js/campaigns-block.js
@@ -1,7 +1,7 @@
 const __ = window.wp.i18n.__
 const { registerBlockType } = window.wp.blocks
-const { useBlockProps, InspectorControls } = window.wp.blockEditor
-const { PanelBody, RangeControl, SelectControl, ToggleControl } = window.wp.components
+const { useBlockProps, InspectorControls } = window.wp.blockEditor // eslint-disable-line no-unused-vars
+const { PanelBody, RangeControl, SelectControl, ToggleControl } = window.wp.components // eslint-disable-line no-unused-vars
 
 registerBlockType('mailchimp-for-wp/campaigns', {
   apiVersion: 3,

--- a/autoload.php
+++ b/autoload.php
@@ -24,6 +24,7 @@ spl_autoload_register(function ($class) {
         'MC4WP_BuddyPress_Integration' => '/integrations/buddypress/class-buddypress.php',
         'MC4WP_Comment_Form_Integration' => '/integrations/wp-comment-form/class-comment-form.php',
         'MC4WP_Contact_Form_7_Integration' => '/integrations/contact-form-7/class-contact-form-7.php',
+        'MC4WP_Campaign_Archive' => '/includes/campaigns/class-archive.php',
         'MC4WP_Container' => '/includes/class-container.php',
         'MC4WP_Custom_Integration' => '/integrations/custom/class-custom.php',
         'MC4WP_Debug_Log' => '/includes/class-debug-log.php',

--- a/includes/campaigns/class-archive.php
+++ b/includes/campaigns/class-archive.php
@@ -159,7 +159,7 @@ class MC4WP_Campaign_Archive
      *
      * @since 4.13.0
      * @param int $count Maximum number of campaigns to retrieve.
-     * @return array
+     * @return array|string
      */
     private function get_campaigns($count)
     {
@@ -188,7 +188,7 @@ class MC4WP_Campaign_Archive
             }
         } catch (MC4WP_API_Exception $e) {
             // Log API errors gracefully, do not break the page.
-            mc4wp_log('Campaign Archive: ' . $e->getMessage());
+            mc4wp('log')->error('Campaign Archive: ' . $e->getMessage());
             return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive Error: ' . esc_html($e->getMessage()) . ' -->' : '';
         }
 

--- a/includes/campaigns/class-archive.php
+++ b/includes/campaigns/class-archive.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Handles the Mailchimp campaign archive shortcode and Gutenberg block.
+ *
+ * @class   MC4WP_Campaign_Archive
+ * @since   4.13.0
+ * @access  public
+ */
+class MC4WP_Campaign_Archive
+{
+    const SHORTCODE = 'mc4wp_campaigns';
+
+    /**
+     * Add hooks.
+     *
+     * @return void
+     */
+    public function add_hooks()
+    {
+        add_shortcode(self::SHORTCODE, [ $this, 'shortcode' ]);
+        add_action('init', [ $this, 'register_block_type' ]);
+        add_action('enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ]);
+    }
+
+    /**
+     * Enqueue block editor assets for the campaign archive block.
+     *
+     * @since 4.13.0
+     * @return void
+     */
+    public function enqueue_block_editor_assets()
+    {
+        wp_enqueue_script(
+            'mc4wp-campaigns-block',
+            mc4wp_plugin_url('assets/js/campaigns-block.js'),
+            [
+                'wp-blocks',
+                'wp-i18n',
+                'wp-element',
+                'wp-components',
+                'wp-block-editor',
+            ],
+            MC4WP_VERSION,
+            true
+        );
+    }
+
+    /**
+     * Register the Gutenberg block type.
+     *
+     * @since 4.13.0
+     * @return void
+     */
+    public function register_block_type()
+    {
+        if (! function_exists('register_block_type')) {
+            return;
+        }
+
+        register_block_type(
+            'mailchimp-for-wp/campaigns',
+            [
+                'render_callback' => [ $this, 'shortcode' ],
+                'attributes'      => [
+                    'count'      => [
+                        'type'    => 'integer',
+                        'default' => 10,
+                    ],
+                    'title_type' => [
+                        'type'    => 'string',
+                        'default' => 'title',
+                    ],
+                    'show_date'  => [
+                        'type'    => 'boolean',
+                        'default' => true,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Shortcode handler. Also used as the Gutenberg block render callback.
+     *
+     * @since 4.13.0
+     * @param array $attributes Shortcode or block attributes.
+     * @return string
+     */
+    public function shortcode($attributes = [])
+    {
+        $attributes = shortcode_atts(
+            [
+                'count'      => 10,
+                'title_type' => 'title', // 'title' or 'subject_line'
+                'show_date'  => true,
+            ],
+            $attributes,
+            self::SHORTCODE
+        );
+
+        $count      = absint($attributes['count']);
+        $title_type = in_array($attributes['title_type'], [ 'title', 'subject_line' ], true)
+            ? $attributes['title_type']
+            : 'title';
+        $show_date  = filter_var($attributes['show_date'], FILTER_VALIDATE_BOOLEAN);
+
+        $campaigns = $this->get_campaigns($count);
+
+        if (empty($campaigns) || ! is_array($campaigns)) {
+            return is_string($campaigns) ? $campaigns : '';
+        }
+
+        $html = '<ul class="mc4wp-campaign-archive">';
+
+        foreach ($campaigns as $campaign) {
+            $archive_url = isset($campaign->long_archive_url) ? $campaign->long_archive_url : '';
+
+            $label = isset($campaign->settings->{$title_type}) ? $campaign->settings->{$title_type} : '';
+
+            if (empty($label)) {
+                $label = isset($campaign->settings->title) ? $campaign->settings->title : '';
+            }
+
+            if (empty($archive_url) || empty($label)) {
+                continue;
+            }
+
+            $html .= '<li class="mc4wp-campaign-archive__item">';
+            $html .= '<a class="mc4wp-campaign-archive__link" href="' . esc_url($archive_url) . '">';
+            $html .= esc_html($label);
+            $html .= '</a>';
+
+            if ($show_date && ! empty($campaign->send_time)) {
+                $timestamp = strtotime($campaign->send_time);
+                if ($timestamp) {
+                    $html .= ' <span class="mc4wp-campaign-archive__date">';
+                    /* translators: %s: Campaign send date. */
+                    $html .= sprintf(
+                        esc_html__('(%s)', 'mailchimp-for-wp'),
+                        esc_html(date_i18n(get_option('date_format'), $timestamp))
+                    );
+                    $html .= '</span>';
+                }
+            }
+
+            $html .= '</li>';
+        }
+
+        $html .= '</ul>';
+
+        return $html;
+    }
+
+    /**
+     * Fetch sent campaigns from the Mailchimp API, with transient caching.
+     *
+     * Results are cached for 1 hour per (count) combination to reduce API requests.
+     *
+     * @since 4.13.0
+     * @param int $count Maximum number of campaigns to retrieve.
+     * @return array
+     */
+    private function get_campaigns($count)
+    {
+        $transient_key = 'mc4wp_campaigns_v2_' . $count;
+        $cached        = get_transient($transient_key);
+
+        if (false !== $cached) {
+            return $cached;
+        }
+
+        try {
+            $api = mc4wp_get_api_v3();
+
+            $result = $api->get_campaigns([
+                'status'        => 'sent',
+                'count'         => $count,
+                'sort_field'    => 'send_time',
+                'sort_dir'      => 'DESC',
+                'fields'        => 'campaigns.id,campaigns.settings.title,campaigns.settings.subject_line,campaigns.send_time,campaigns.long_archive_url',
+            ]);
+
+            if (is_object($result) && isset($result->campaigns) && is_array($result->campaigns)) {
+                $campaigns = $result->campaigns;
+            } else {
+                return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive: Invalid API response format -->' : '';
+            }
+        } catch (MC4WP_API_Exception $e) {
+            // Log API errors gracefully, do not break the page.
+            mc4wp_log('Campaign Archive: ' . $e->getMessage());
+            return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive Error: ' . esc_html($e->getMessage()) . ' -->' : '';
+        }
+
+        if (! is_array($campaigns)) {
+            return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive: No campaigns array found. -->' : '';
+        }
+
+        if (empty($campaigns)) {
+            return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive: Zero campaigns returned from Mailchimp. -->' : '';
+        }
+
+        set_transient($transient_key, $campaigns, HOUR_IN_SECONDS);
+
+        return $campaigns;
+    }
+}

--- a/includes/campaigns/class-archive.php
+++ b/includes/campaigns/class-archive.php
@@ -192,10 +192,6 @@ class MC4WP_Campaign_Archive
             return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive Error: ' . esc_html($e->getMessage()) . ' -->' : '';
         }
 
-        if (! is_array($campaigns)) {
-            return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive: No campaigns array found. -->' : '';
-        }
-
         if (empty($campaigns)) {
             return current_user_can('manage_options') ? '<!-- MC4WP Campaign Archive: Zero campaigns returned from Mailchimp. -->' : '';
         }

--- a/mailchimp-for-wp.php
+++ b/mailchimp-for-wp.php
@@ -66,6 +66,9 @@ add_action('plugins_loaded', function () {
     $form_manager->add_hooks();
     $mc4wp['forms'] = $form_manager;
 
+    // campaign archive
+    ( new MC4WP_Campaign_Archive() )->add_hooks();
+
     // integration core
     $integration_manager = new MC4WP_Integration_Manager();
     $integration_manager->add_hooks();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     'forms-submitted': './assets/src/js/forms-submitted.js',
     'forms-admin': './assets/src/js/forms-admin.js',
     'forms-block': './assets/src/js/forms-block.js',
+    'campaigns-block': './assets/src/js/campaigns-block.js',
     'email-typo-checker': './assets/src/js/forms/email-typo-checker.js'
   },
   output: {


### PR DESCRIPTION
## Summary

Adds a new shortcode `[mc4wp_campaigns]` and a native Gutenberg block to display an archive of sent Mailchimp campaigns directly on a WordPress site.

Fixes #811

## Problem

Users currently lack an official, built-in way to display their Mailchimp campaign history on their sites without relying on third-party plugins or manual embeds.

## Solution

Implemented a WordPress shortcode and a Gutenberg block that fetch and render the user's sent campaigns. We use the existing `MC4WP_API_V3` wrapper and transient caching to ensure performance and prevent rate-limiting.

## Changes

### `includes/campaigns/class-archive.php`

**Before:**
```php
// File didn't exist
```

**After:**
```php
public function shortcode($attributes = []) {
    // ...
    $campaigns = $this->get_campaigns($count);
    if (empty($campaigns) || ! is_array($campaigns)) {
        return is_string($campaigns) ? $campaigns : '';
    }
    // ...
}
```

**Why:** Centralized logic for both the shortcode and server-side block rendering. It correctly extracts the campaigns array from the API response object and leverages transient caching.

### `assets/src/js/campaigns-block.js`

**Before:**
```javascript
// File didn't exist
```

**After:**
```javascript
edit: function ({ attributes, setAttributes }) {
    return (
      <div>
        <InspectorControls>
          // ...
        </InspectorControls>
        // ...
      </div>
    )
}
```

**Why:** Registers editor UI that aligns with `mailchimp-for-wp` standards. It is explicitly wrapped in standard `<div>` instead of React Fragment `<>` syntax to guarantee `@babel/preset-env` compatibility during compilation.

## Testing

**Test 1: Shortcode Rendering**
Steps: 
1) Added `[mc4wp_campaigns]` 
2) Verified shortcode maps settings correctly 
3) Cached on load

Result: Works as expected

**Test 2: Transient Caching & API Errors**
Steps: 
1) Disconnected API 
2) View frontend 
3) Handled gracefully with HTML debug comment for admins only

Result: Handled correctly

**Automated:**
```bash
$ composer run-script test
OK (62 tests, 190 assertions)

$ vendor/bin/phpcs -n -s
Exit code: 0
```

## Build
[mailchimp-for-wp-feature-811.zip](https://github.com/user-attachments/files/26173407/mailchimp-for-wp-feature-811.zip) available for manual testing
Install: WP Admin → Plugins → Upload

## Screenshot 
<img width="1915" height="690" alt="image" src="https://github.com/user-attachments/assets/64fbe34e-48c1-4ad3-89e9-adb99864f90e" />

<img width="898" height="315" alt="image" src="https://github.com/user-attachments/assets/067fbfc0-b87c-4f66-9a1f-643a548d42bc" />
