### PR TITLE
feat: Automate Mailchimp Site Tracking Pixel connection (fixes #830)

### DIFF
--- a/config/default-settings.php
+++ b/config/default-settings.php
@@ -1,8 +1,10 @@
 <?php
 
 return [
-    'api_key'              => '',
-    'debug_log_level'      => 'warning',
-    'email_on_error'       => '',
-    'tracking_pixel_id'    => '',
+    'api_key'                    => '',
+    'debug_log_level'            => 'warning',
+    'email_on_error'             => '',
+    'tracking_pixel_enabled'     => false,
+    'tracking_pixel_site_id'     => '',
+    'tracking_pixel_script_url'  => '',
 ];

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -62,6 +62,7 @@ class MC4WP_Admin
         add_action('wp_dashboard_setup', [$this, 'register_dashboard_widgets']);
         add_action('mc4wp_admin_empty_lists_cache', [$this, 'renew_lists_cache']);
         add_action('mc4wp_admin_empty_debug_log', [$this, 'empty_debug_log']);
+        add_action('mc4wp_admin_connect_tracking_pixel', [$this, 'connect_tracking_pixel']);
 
         add_action('admin_notices', [$this, 'show_api_key_notice']);
         add_action('mc4wp_admin_dismiss_api_key_notice', [$this, 'dismiss_api_key_notice']);
@@ -244,9 +245,27 @@ class MC4WP_Admin
         // Sanitize API key
         $settings['api_key'] = sanitize_text_field($settings['api_key']);
 
-        // Sanitize tracking pixel ID (alphanumeric and hyphens only)
-        if (isset($settings['tracking_pixel_id'])) {
-            $settings['tracking_pixel_id'] = preg_replace('/[^a-zA-Z0-9\-]/', '', $settings['tracking_pixel_id']);
+        // Sanitize tracking pixel enabled toggle
+        $settings['tracking_pixel_enabled'] = ! empty($settings['tracking_pixel_enabled']);
+
+        // If the toggle was just switched on, trigger auto-connect to fetch/create the connected site
+        if ($settings['tracking_pixel_enabled'] && empty($settings['tracking_pixel_site_id'])) {
+            $success = MC4WP_Tracking_Pixel::fetch_or_create_connected_site();
+            if ($success) {
+                // Re-read options as fetch_or_create_connected_site() updates them
+                $refreshed = mc4wp_get_options();
+                $settings['tracking_pixel_site_id']   = $refreshed['tracking_pixel_site_id'];
+                $settings['tracking_pixel_script_url'] = $refreshed['tracking_pixel_script_url'];
+            } else {
+                $this->messages->flash(esc_html__('Could not automatically connect your site to Mailchimp. Please check your API key and try again.', 'mailchimp-for-wp'), 'error');
+                $settings['tracking_pixel_enabled'] = false;
+            }
+        }
+
+        // If the toggle is turned off, clear stored site info
+        if (! $settings['tracking_pixel_enabled']) {
+            $settings['tracking_pixel_site_id']   = '';
+            $settings['tracking_pixel_script_url'] = '';
         }
 
         // if API key changed, empty Mailchimp cache
@@ -460,6 +479,20 @@ class MC4WP_Admin
         $pos_a = isset($a['position']) ? $a['position'] : 80;
         $pos_b = isset($b['position']) ? $b['position'] : 90;
         return $pos_a < $pos_b ? -1 : 1;
+    }
+
+    /**
+     * Re-runs the connected site auto-connect flow (useful if the site was
+     * registered under a different domain or the stored site_id is stale).
+     */
+    public function connect_tracking_pixel()
+    {
+        $success = MC4WP_Tracking_Pixel::fetch_or_create_connected_site();
+        if ($success) {
+            $this->messages->flash(esc_html__('Site tracking pixel successfully connected.', 'mailchimp-for-wp'));
+        } else {
+            $this->messages->flash(esc_html__('Could not connect site tracking pixel. Please check your API key and try again.', 'mailchimp-for-wp'), 'error');
+        }
     }
 
     /**

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -250,12 +250,10 @@ class MC4WP_Admin
 
         // If the toggle was just switched on, trigger auto-connect to fetch/create the connected site
         if ($settings['tracking_pixel_enabled'] && empty($settings['tracking_pixel_site_id'])) {
-            $success = MC4WP_Tracking_Pixel::fetch_or_create_connected_site();
-            if ($success) {
-                // Re-read options as fetch_or_create_connected_site() updates them
-                $refreshed = mc4wp_get_options();
-                $settings['tracking_pixel_site_id']   = $refreshed['tracking_pixel_site_id'];
-                $settings['tracking_pixel_script_url'] = $refreshed['tracking_pixel_script_url'];
+            $result = MC4WP_Tracking_Pixel::fetch_or_create_connected_site();
+            if ($result !== false) {
+                $settings['tracking_pixel_site_id']   = $result['site_id'];
+                $settings['tracking_pixel_script_url'] = $result['script_url'];
             } else {
                 $this->messages->flash(esc_html__('Could not automatically connect your site to Mailchimp. Please check your API key and try again.', 'mailchimp-for-wp'), 'error');
                 $settings['tracking_pixel_enabled'] = false;
@@ -487,8 +485,13 @@ class MC4WP_Admin
      */
     public function connect_tracking_pixel()
     {
-        $success = MC4WP_Tracking_Pixel::fetch_or_create_connected_site();
-        if ($success) {
+        $result = MC4WP_Tracking_Pixel::fetch_or_create_connected_site();
+        if ($result !== false) {
+            $opts = mc4wp_get_options();
+            $opts['tracking_pixel_enabled']    = true;
+            $opts['tracking_pixel_site_id']    = $result['site_id'];
+            $opts['tracking_pixel_script_url'] = $result['script_url'];
+            update_option('mc4wp', $opts);
             $this->messages->flash(esc_html__('Site tracking pixel successfully connected.', 'mailchimp-for-wp'));
         } else {
             $this->messages->flash(esc_html__('Could not connect site tracking pixel. Please check your API key and try again.', 'mailchimp-for-wp'), 'error');

--- a/includes/api/class-api-v3.php
+++ b/includes/api/class-api-v3.php
@@ -395,6 +395,42 @@ class MC4WP_API_V3
     }
 
     /**
+     * Get all connected sites for the Mailchimp account.
+     *
+     * @link https://mailchimp.com/developer/marketing/api/connected-sites/get-connected-site/
+     *
+     * @param array $args
+     *
+     * @return array
+     * @throws MC4WP_API_Exception
+     */
+    public function get_connected_sites(array $args = [])
+    {
+        $data = $this->client->get('/connected-sites', $args);
+
+        if (is_object($data) && isset($data->sites)) {
+            return $data->sites;
+        }
+
+        return [];
+    }
+
+    /**
+     * Add (register) a new connected site.
+     *
+     * @link https://mailchimp.com/developer/marketing/api/connected-sites/add-connected-site/
+     *
+     * @param array $args  Must include 'foreign_id' and 'domain'.
+     *
+     * @return object
+     * @throws MC4WP_API_Exception
+     */
+    public function add_connected_site(array $args)
+    {
+        return $this->client->post('/connected-sites', $args);
+    }
+
+    /**
      * @link https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/#read-get_ecommerce_stores
      *
      * @param array $args

--- a/includes/class-tracking-pixel.php
+++ b/includes/class-tracking-pixel.php
@@ -54,6 +54,11 @@ class MC4WP_Tracking_Pixel
         $opts = mc4wp_get_options();
         $url  = $opts['tracking_pixel_script_url'] ?? '';
 
+        // BC: support legacy tracking_pixel_id for users who configured it before this auto-connect feature
+        if (empty($url) && ! empty($opts['tracking_pixel_id'])) {
+            $url = sprintf('https://chimpstatic.com/mcjs-connected/js/users/%s.js', $opts['tracking_pixel_id']);
+        }
+
         if (empty($url)) {
             return;
         }
@@ -107,13 +112,11 @@ class MC4WP_Tracking_Pixel
      * Auto-fetch an existing Mailchimp Connected Site that matches the current domain,
      * or create a new one if none is found.
      *
-     * Saves 'tracking_pixel_site_id' and 'tracking_pixel_script_url' into the mc4wp options.
-     *
      * @since 4.13.0
      *
-     * @return bool  True on success, false on failure.
+     * @return array{site_id: string, script_url: string}|false  Array with site data on success, false on failure.
      */
-    public static function fetch_or_create_connected_site(): bool
+    public static function fetch_or_create_connected_site()
     {
         try {
             /** @var MC4WP_API_V3 $api */
@@ -141,21 +144,12 @@ class MC4WP_Tracking_Pixel
                 ]);
             }
 
-            // Persist the site ID and script URL into plugin options.
-            $site_id    = $matched_site->foreign_id ?? $matched_site->id ?? '';
-            $script_url = $matched_site->site_script->url ?? '';
-
-            $opts = mc4wp_get_options();
-            $opts['tracking_pixel_site_id']   = sanitize_text_field($site_id);
-            $opts['tracking_pixel_script_url'] = esc_url_raw($script_url);
-            update_option('mc4wp', $opts);
-
-            return true;
+            return [
+                'site_id'    => sanitize_text_field($matched_site->foreign_id ?? $matched_site->id ?? ''),
+                'script_url' => esc_url_raw($matched_site->site_script->url ?? ''),
+            ];
         } catch (Exception $e) {
-            // Log but don't crash.
-            if (function_exists('mc4wp')) {
-                mc4wp('log')->error(sprintf('Tracking Pixel: error fetching/creating connected site. %s', $e->getMessage()));
-            }
+            mc4wp('log')->error(sprintf('Tracking Pixel: error fetching/creating connected site. %s', $e->getMessage()));
             return false;
         }
     }

--- a/includes/class-tracking-pixel.php
+++ b/includes/class-tracking-pixel.php
@@ -11,9 +11,9 @@
 class MC4WP_Tracking_Pixel
 {
     /**
-     * @var string The tracking pixel ID from settings.
+     * @var string The foreign_id / site_id used to identify the connected site in Mailchimp.
      */
-    private $tracking_id;
+    private $site_id;
 
     /**
      * @var string Email address of a subscriber to identify, set during form processing.
@@ -21,11 +21,11 @@ class MC4WP_Tracking_Pixel
     private $identify_email = '';
 
     /**
-     * @param string $tracking_id The Mailchimp tracking pixel ID.
+     * @param string $site_id The connected site ID stored in the plugin options.
      */
-    public function __construct(string $tracking_id)
+    public function __construct(string $site_id)
     {
-        $this->tracking_id = $tracking_id;
+        $this->site_id = $site_id;
     }
 
     /**
@@ -47,11 +47,16 @@ class MC4WP_Tracking_Pixel
      */
     public function output_tracking_script(): void
     {
-        if (empty($this->tracking_id)) {
+        if (empty($this->site_id)) {
             return;
         }
 
-        $url = 'https://mc.mailchimp.com/mcjs/' . urlencode($this->tracking_id) . '.js';
+        $opts = mc4wp_get_options();
+        $url  = $opts['tracking_pixel_script_url'] ?? '';
+
+        if (empty($url)) {
+            return;
+        }
 
         printf(
             '<script id="mcjs" defer src="%s"></script>' . "\n",
@@ -66,7 +71,7 @@ class MC4WP_Tracking_Pixel
      *
      * @since 4.13.0
      *
-     * @param MC4WP_Form $form The submitted form instance.
+     * @param MC4WP_Form $form  The submitted form instance.
      * @param string     $email The subscriber's email address.
      * @return void
      */
@@ -86,7 +91,7 @@ class MC4WP_Tracking_Pixel
      */
     public function output_identify_script(): void
     {
-        if (empty($this->identify_email) || empty($this->tracking_id)) {
+        if (empty($this->identify_email) || empty($this->site_id)) {
             return;
         }
 
@@ -96,5 +101,113 @@ class MC4WP_Tracking_Pixel
         echo 'window.$mcSite.pixel.api.identify({type:"EMAIL",value:"' . $email . '"});';
         echo '}';
         echo '</script>' . "\n";
+    }
+
+    /**
+     * Auto-fetch an existing Mailchimp Connected Site that matches the current domain,
+     * or create a new one if none is found.
+     *
+     * Saves 'tracking_pixel_site_id' and 'tracking_pixel_script_url' into the mc4wp options.
+     *
+     * @since 4.13.0
+     *
+     * @return bool  True on success, false on failure.
+     */
+    public static function fetch_or_create_connected_site(): bool
+    {
+        try {
+            /** @var MC4WP_API_V3 $api */
+            $api    = mc4wp('api');
+            $domain = self::get_site_domain();
+            $sites  = $api->get_connected_sites();
+
+            // Try to find an existing site that matches our domain.
+            $matched_site = null;
+            foreach ($sites as $site) {
+                $site_domain = isset($site->domain) ? self::normalize_domain($site->domain) : '';
+                if ($site_domain === self::normalize_domain($domain)) {
+                    $matched_site = $site;
+                    break;
+                }
+            }
+
+            if (null === $matched_site) {
+                // No match — create a new connected site using the e-commerce store ID as foreign_id
+                // so it reuses any existing store connection where possible.
+                $foreign_id   = self::get_foreign_id();
+                $matched_site = $api->add_connected_site([
+                    'foreign_id' => $foreign_id,
+                    'domain'     => $domain,
+                ]);
+            }
+
+            // Persist the site ID and script URL into plugin options.
+            $site_id    = $matched_site->foreign_id ?? $matched_site->id ?? '';
+            $script_url = $matched_site->site_script->url ?? '';
+
+            $opts = mc4wp_get_options();
+            $opts['tracking_pixel_site_id']   = sanitize_text_field($site_id);
+            $opts['tracking_pixel_script_url'] = esc_url_raw($script_url);
+            update_option('mc4wp', $opts);
+
+            return true;
+        } catch (Exception $e) {
+            // Log but don't crash.
+            if (function_exists('mc4wp')) {
+                mc4wp('log')->error(sprintf('Tracking Pixel: error fetching/creating connected site. %s', $e->getMessage()));
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Returns the domain of the current site stripped of protocol.
+     *
+     * @return string
+     */
+    public static function get_site_domain(): string
+    {
+        return (string) self::normalize_domain(get_home_url());
+    }
+
+    /**
+     * Strips protocol and trailing slashes from a URL/domain for comparison.
+     *
+     * @param string $url
+     * @return string
+     */
+    private static function normalize_domain(string $url): string
+    {
+        $domain = str_ireplace(['https://', 'http://', '://'], '', trim($url));
+        return rtrim($domain, '/');
+    }
+
+    /**
+     * Returns a foreign_id to use when registering a new connected site.
+     * Reuses the e-commerce store ID when available so Mailchimp can link them.
+     *
+     * @return string
+     */
+    private static function get_foreign_id(): string
+    {
+        $ecommerce_settings = get_option('mc4wp_ecommerce', []);
+        if (! empty($ecommerce_settings['store_id'])) {
+            return (string) $ecommerce_settings['store_id'];
+        }
+
+        return 'mc4wp-' . sanitize_title(get_bloginfo('name')) . '-' . get_current_blog_id();
+    }
+
+    /**
+     * Returns true if the MC4WP Premium e-commerce integration is already
+     * managing the tracking pixel (mcjs script), so we avoid injecting a
+     * duplicate script on the frontend.
+     *
+     * @return bool
+     */
+    public static function is_premium_ecommerce_pixel_active(): bool
+    {
+        $ecommerce_settings = get_option('mc4wp_ecommerce', []);
+        return ! empty($ecommerce_settings['load_mcjs_script']);
     }
 }

--- a/includes/views/other-settings.php
+++ b/includes/views/other-settings.php
@@ -62,22 +62,40 @@ defined('ABSPATH') or exit;
 
                 <div class="mc4wp-margin-m">
                     <h3><?php echo esc_html__('Site Tracking Pixel', 'mailchimp-for-wp'); ?></h3>
+                    <?php if (MC4WP_Tracking_Pixel::is_premium_ecommerce_pixel_active()) : ?>
+                        <p class="description">
+                            <?php echo wp_kses(
+                                __('<strong>Note:</strong> Site tracking is currently managed by the <strong>MC4WP Premium E-Commerce</strong> integration. You do not need to configure it here.', 'mailchimp-for-wp'),
+                                ['strong' => []]
+                            ); ?>
+                        </p>
+                    <?php else : ?>
                     <table class="form-table">
                         <tr>
-                            <th><label for="mc4wp-tracking-pixel-id"><?php echo esc_html__('Tracking Pixel ID', 'mailchimp-for-wp'); ?></label></th>
+                            <th><label for="mc4wp-tracking-pixel-enabled"><?php echo esc_html__('Enable Site Tracking', 'mailchimp-for-wp'); ?></label></th>
                             <td>
-                                <input type="text" id="mc4wp-tracking-pixel-id" name="mc4wp[tracking_pixel_id]" value="<?php echo esc_attr($opts['tracking_pixel_id']); ?>" class="regular-text" placeholder="" />
+                                <label>
+                                    <input type="checkbox" id="mc4wp-tracking-pixel-enabled" name="mc4wp[tracking_pixel_enabled]" value="1" <?php checked(true, ! empty($opts['tracking_pixel_enabled'])); ?> />
+                                    <?php echo esc_html__('Load the Mailchimp Site Tracking Pixel on all frontend pages.', 'mailchimp-for-wp'); ?>
+                                </label>
                                 <p class="description">
-                                    <?php echo esc_html__('Enter your Mailchimp Site Tracking Pixel ID to enable visitor tracking on your site.', 'mailchimp-for-wp'); ?>
-                                    <a href="https://mailchimp.com/help/mailchimp-site-tracking-pixel-integration-guidance/" target="_blank"><?php echo esc_html__('Learn more about the tracking pixel.', 'mailchimp-for-wp'); ?></a>
+                                    <?php echo esc_html__('When enabled, the plugin automatically finds or registers your site in Mailchimp and loads the tracking script. Subscribers who sign up via your forms will be automatically identified.', 'mailchimp-for-wp'); ?>
+                                    <a href="https://mailchimp.com/help/mailchimp-site-tracking-pixel-integration-guidance/" target="_blank"><?php echo esc_html__('Learn more.', 'mailchimp-for-wp'); ?></a>
                                 </p>
-                                <p class="description">
-                                    <?php echo esc_html__('When configured, the Mailchimp tracking script will be loaded on all frontend pages. Subscribers who sign up via your forms will be automatically identified.', 'mailchimp-for-wp'); ?>
-                                </p>
+                                <?php if (! empty($opts['tracking_pixel_site_id'])) : ?>
+                                    <p class="description">
+                                        <strong><?php echo esc_html__('Connected Site ID:', 'mailchimp-for-wp'); ?></strong>
+                                        <code><?php echo esc_html($opts['tracking_pixel_site_id']); ?></code>
+                                        &nbsp;&mdash;&nbsp;
+                                        <a href="<?php echo esc_url(wp_nonce_url(add_query_arg(['_mc4wp_action' => 'connect_tracking_pixel', '_redirect_to' => remove_query_arg('_mc4wp_action')]), '_mc4wp_action')); ?>"><?php echo esc_html__('Re-connect', 'mailchimp-for-wp'); ?></a>
+                                    </p>
+                                <?php endif; ?>
                             </td>
                         </tr>
                     </table>
+                    <?php endif; ?>
                 </div>
+
 
                 <?php do_action('mc4wp_admin_other_settings', $opts); ?>
 

--- a/includes/views/other-settings.php
+++ b/includes/views/other-settings.php
@@ -87,7 +87,7 @@ defined('ABSPATH') or exit;
                                         <strong><?php echo esc_html__('Connected Site ID:', 'mailchimp-for-wp'); ?></strong>
                                         <code><?php echo esc_html($opts['tracking_pixel_site_id']); ?></code>
                                         &nbsp;&mdash;&nbsp;
-                                        <a href="<?php echo esc_url(wp_nonce_url(add_query_arg(['_mc4wp_action' => 'connect_tracking_pixel', '_redirect_to' => remove_query_arg('_mc4wp_action')]), '_mc4wp_action')); ?>"><?php echo esc_html__('Re-connect', 'mailchimp-for-wp'); ?></a>
+                                        <a href="<?php echo esc_url(wp_nonce_url(add_query_arg(['_mc4wp_action' => 'connect_tracking_pixel']), '_mc4wp_action')); ?>"><?php echo esc_html__('Re-connect', 'mailchimp-for-wp'); ?></a>
                                     </p>
                                 <?php endif; ?>
                             </td>

--- a/mailchimp-for-wp.php
+++ b/mailchimp-for-wp.php
@@ -91,12 +91,16 @@ add_action('plugins_loaded', function () {
     // Initialize tracking pixel on frontend
     if (! is_admin()) {
         $opts = mc4wp_get_options();
+
+        // Determine the site ID: prefer new auto-connected value, fall back to legacy manual ID
+        $site_id = ! empty($opts['tracking_pixel_site_id']) ? $opts['tracking_pixel_site_id'] : ($opts['tracking_pixel_id'] ?? '');
+
         if (
-            ! empty($opts['tracking_pixel_enabled'])
-            && ! empty($opts['tracking_pixel_site_id'])
+            (! empty($opts['tracking_pixel_enabled']) || ! empty($opts['tracking_pixel_id']))
+            && ! empty($site_id)
             && ! MC4WP_Tracking_Pixel::is_premium_ecommerce_pixel_active()
         ) {
-            $tracking_pixel = new MC4WP_Tracking_Pixel($opts['tracking_pixel_site_id']);
+            $tracking_pixel = new MC4WP_Tracking_Pixel($site_id);
             $tracking_pixel->add_hooks();
         }
     }

--- a/mailchimp-for-wp.php
+++ b/mailchimp-for-wp.php
@@ -91,8 +91,12 @@ add_action('plugins_loaded', function () {
     // Initialize tracking pixel on frontend
     if (! is_admin()) {
         $opts = mc4wp_get_options();
-        if (! empty($opts['tracking_pixel_id'])) {
-            $tracking_pixel = new MC4WP_Tracking_Pixel($opts['tracking_pixel_id']);
+        if (
+            ! empty($opts['tracking_pixel_enabled'])
+            && ! empty($opts['tracking_pixel_site_id'])
+            && ! MC4WP_Tracking_Pixel::is_premium_ecommerce_pixel_active()
+        ) {
+            $tracking_pixel = new MC4WP_Tracking_Pixel($opts['tracking_pixel_site_id']);
             $tracking_pixel->add_hooks();
         }
     }


### PR DESCRIPTION
Automates Mailchimp Site Tracking Pixel configuration via the API by connecting sites on user's behalf. 

Fixes #830.

## Overview
- Migrates away from manual ID entry text box to a simple toggle for site tracking.
- Calls Mailchimp API `POST /connected-sites` using the WordPress site `domain`.
- Skips logic and presents notice instead when MC4WP Premium e-commerce module already provides pixel logic.

No breaking changes introduced. Existing manually stored connected sites will need to re-verify domain, but the process has been streamlined to just click the toggle.