### PR TITLE
feat(integrations): process sign-ups in background via WP Cron

### DIFF
--- a/includes/integrations/class-integration-manager.php
+++ b/includes/integrations/class-integration-manager.php
@@ -41,16 +41,16 @@ class MC4WP_Integration_Manager
      *
      * @param array $args
      */
-    public function process_subscribe( $args )
+    public function process_subscribe($args)
     {
-        if ( empty( $args['integration_slug'] ) ) {
+        if (empty($args['integration_slug'])) {
             return;
         }
 
         try {
-            $integration = $this->get( $args['integration_slug'] );
-            $integration->process_background_subscribe( $args );
-        } catch ( Exception $e ) {
+            $integration = $this->get($args['integration_slug']);
+            $integration->process_background_subscribe($args);
+        } catch (Exception $e) {
             // Integration not found
         }
     }

--- a/includes/integrations/class-integration-manager.php
+++ b/includes/integrations/class-integration-manager.php
@@ -31,8 +31,28 @@ class MC4WP_Integration_Manager
     public function add_hooks()
     {
         add_action('after_setup_theme', [ $this, 'initialize' ]);
+        add_action('mc4wp_integration_subscribe', [ $this, 'process_subscribe' ]);
 
         $this->tags->add_hooks();
+    }
+
+    /**
+     * Process background subscription
+     *
+     * @param array $args
+     */
+    public function process_subscribe( $args )
+    {
+        if ( empty( $args['integration_slug'] ) ) {
+            return;
+        }
+
+        try {
+            $integration = $this->get( $args['integration_slug'] );
+            $integration->process_background_subscribe( $args );
+        } catch ( Exception $e ) {
+            // Integration not found
+        }
     }
 
 

--- a/includes/integrations/class-integration.php
+++ b/includes/integrations/class-integration.php
@@ -416,19 +416,19 @@ abstract class MC4WP_Integration
          */
         $data = apply_filters("mc4wp_integration_{$this->slug}_data", $data, $related_object_id);
 
-        $args = array(
+        $args = [
             'integration_slug'  => $this->slug,
             'data'              => $data,
             'related_object_id' => $related_object_id,
             'list_ids'          => $list_ids,
             'ip_signup'         => mc4wp_get_request_ip_address(),
             'email_type'        => mc4wp_get_email_type(),
-        );
+        ];
 
-        if ( function_exists( 'as_enqueue_async_action' ) ) {
-            as_enqueue_async_action( 'mc4wp_integration_subscribe', array( $args ) );
+        if (function_exists('as_enqueue_async_action')) {
+            as_enqueue_async_action('mc4wp_integration_subscribe', [$args]);
         } else {
-            wp_schedule_single_event( time(), 'mc4wp_integration_subscribe', array( $args ) );
+            wp_schedule_single_event(time(), 'mc4wp_integration_subscribe', [$args]);
         }
 
         return true;

--- a/includes/integrations/class-integration.php
+++ b/includes/integrations/class-integration.php
@@ -390,15 +390,8 @@ abstract class MC4WP_Integration
      */
     protected function subscribe(array $data, $related_object_id = 0)
     {
-        $integration = $this;
-        $slug        = $this->slug;
-        $mailchimp   = new MC4WP_MailChimp();
         $log         = $this->get_log();
         $list_ids    = $this->get_lists();
-
-        /** @var null|MC4WP_MailChimp_Subscriber $subscriber */
-        $subscriber = null;
-        $result     = false;
 
         // validate lists
         if (empty($list_ids)) {
@@ -421,9 +414,48 @@ abstract class MC4WP_Integration
          * @param array $data
          * @param int $related_object_id
          */
-        $data = apply_filters("mc4wp_integration_{$slug}_data", $data, $related_object_id);
+        $data = apply_filters("mc4wp_integration_{$this->slug}_data", $data, $related_object_id);
 
-        $email_type = mc4wp_get_email_type();
+        $args = array(
+            'integration_slug'  => $this->slug,
+            'data'              => $data,
+            'related_object_id' => $related_object_id,
+            'list_ids'          => $list_ids,
+            'ip_signup'         => mc4wp_get_request_ip_address(),
+            'email_type'        => mc4wp_get_email_type(),
+        );
+
+        if ( function_exists( 'as_enqueue_async_action' ) ) {
+            as_enqueue_async_action( 'mc4wp_integration_subscribe', array( $args ) );
+        } else {
+            wp_schedule_single_event( time(), 'mc4wp_integration_subscribe', array( $args ) );
+        }
+
+        return true;
+    }
+
+    /**
+     * Process background subscription
+     *
+     * @param array $args
+     * @return boolean
+     */
+    public function process_background_subscribe(array $args)
+    {
+        $data              = $args['data'];
+        $related_object_id = $args['related_object_id'];
+        $list_ids          = $args['list_ids'];
+        $email_type        = $args['email_type'];
+        $ip_signup         = $args['ip_signup'];
+
+        $integration = $this;
+        $slug        = $this->slug;
+        $mailchimp   = new MC4WP_MailChimp();
+        $log         = $this->get_log();
+
+        /** @var null|MC4WP_MailChimp_Subscriber $subscriber */
+        $subscriber = null;
+        $result     = false;
 
         $mapper = new MC4WP_List_Data_Mapper($data, $list_ids);
 
@@ -433,7 +465,7 @@ abstract class MC4WP_Integration
         foreach ($map as $list_id => $subscriber) {
             $subscriber->status     = $this->options['double_optin'] ? 'pending' : 'subscribed';
             $subscriber->email_type = $email_type;
-            $subscriber->ip_signup  = mc4wp_get_request_ip_address();
+            $subscriber->ip_signup  = $ip_signup;
 
             /** @ignore documented elsewhere */
             $subscriber = apply_filters('mc4wp_subscriber_data', $subscriber);


### PR DESCRIPTION
## Summary

Moves integration sign-ups to background processing using Action Scheduler (if available) or the WP Cron system. This significantly reduces form submission response times and improves overall site performance for users.

Fixes #825

## Problem

Currently, when a user signs up through an integration (like WooCommerce or WP-Comment form), the plugin makes a synchronous API request to Mailchimp. This forces the user to wait for the network request to complete before the page loads, harming UX.

## Solution

The sign-up logic is now deferred to a background task (`mc4wp_integration_subscribe`). We capture all necessary context (request data, IP address, email type) at the moment of submission to ensure data accuracy while offloading the API request itself.

## Changes

### `includes/integrations/class-integration.php`

**Before:**
```php
protected function subscribe(array $data, $related_object_id = 0)
{
    // ... logic ...
    $result = $mailchimp->list_subscribe(...);
    // ... logic ...
}
```

**After:**
```php
protected function subscribe(array $data, $related_object_id = 0)
{
    // Collect context and enqueue action
    $args = array(...);
    if ( function_exists( 'as_enqueue_async_action' ) ) {
        as_enqueue_async_action( 'mc4wp_integration_subscribe', array( $args ) );
    } else {
        wp_schedule_single_event( time(), 'mc4wp_integration_subscribe', array( $args ) );
    }
    return true;
}
```

**Why:** Deferring the API call prevents network latency from blocking the user's browser response.

### `includes/integrations/class-integration-manager.php`

**Before:**
```php
public function add_hooks()
{
    add_action('after_setup_theme', [ $this, 'initialize' ]);
    $this->tags->add_hooks();
}
```

**After:**
```php
public function add_hooks()
{
    add_action('after_setup_theme', [ $this, 'initialize' ]);
    add_action('mc4wp_integration_subscribe', [ $this, 'process_subscribe' ]);
    $this->tags->add_hooks();
}
```

**Why:** Registers the background action handler that reinstantiates the correct integration and processes the queued request.

## Testing

**Test 1: Standard Integration Submission**
- Steps: 
1) Enable a contact form integration. 
2) Submit the form.
- Result: Form submission is significantly faster. Subscription appears in MailChimp shortly after.

**Test 2: Context Retention**
- Steps: 
1) Submit form with specific merge fields. 
2) Verify background process uses captured IP and mail type.
- Result: Variables are correctly passed and processed in the background task.

## Build

[mailchimp-for-wordpress-fix-825.zip](https://github.com/user-attachments/files/26906029/mailchimp-for-wordpress-fix-825.zip) is available for manual testing.
