### PR TITLE
Add WooCommerce coupon sync to Mailchimp promo codes

### DIFF
--- a/integrations/woocommerce/admin-after.php
+++ b/integrations/woocommerce/admin-after.php
@@ -48,5 +48,17 @@ $config = [
                 <p class="description"><?php esc_html_e('Select the location where you would like to show the sign-up checkbox. Note that only works if not using WooCommerce Checkout Block.', 'mailchimp-for-wp'); ?></p>
             </td>
         </tr>
+        <tr valign="top">
+            <th scope="row">
+                <?php _e('Sync Coupons', 'mailchimp-for-wp'); ?>
+            </th>
+            <td>
+                <label>
+                    <input type="checkbox" name="mc4wp_integrations[<?php echo $integration->slug; ?>][sync_coupons]" value="1" <?php checked($opts['sync_coupons'], 1); ?> />
+                    <?php _e('Automatically sync WooCommerce coupons to Mailchimp as Promo Rules.', 'mailchimp-for-wp'); ?>
+                </label>
+                <p class="description"><?php _e('This allows you to use your coupons in Mailchimp abandoned cart journeys and other automated emails.', 'mailchimp-for-wp'); ?></p>
+            </td>
+        </tr>
     </tbody>
 </table>

--- a/integrations/woocommerce/class-coupon-sync.php
+++ b/integrations/woocommerce/class-coupon-sync.php
@@ -1,0 +1,316 @@
+<?php
+
+/**
+ * Class MC4WP_WooCommerce_Coupon_Sync
+ *
+ * Syncs WooCommerce coupons to Mailchimp as Promo Rules & Promo Codes.
+ *
+ * @since 4.13.0
+ * @ignore
+ */
+class MC4WP_WooCommerce_Coupon_Sync
+{
+    /**
+     * @var string
+     */
+    private $store_id = '';
+
+    public function __construct()
+    {
+        add_action('save_post_shop_coupon', [$this, 'sync_coupon'], 20, 1);
+        add_action('woocommerce_delete_coupon', [$this, 'delete_coupon'], 10, 1);
+    }
+
+    /**
+     * @param int $coupon_id
+     */
+    public function sync_coupon($coupon_id)
+    {
+        $log = mc4wp_get_debug_log();
+
+        if (get_post_type($coupon_id) !== 'shop_coupon') {
+            return;
+        }
+
+        if (in_array(get_post_status($coupon_id), ['auto-draft', 'trash'], true)) {
+            return;
+        }
+
+        $store_id = $this->get_store_id();
+        if (empty($store_id)) {
+            $log->warning('Coupon Sync > Could not auto-discover a Mailchimp Store ID for this site.');
+            return;
+        }
+
+        $coupon = new WC_Coupon($coupon_id);
+        if (! $coupon->get_id()) {
+            return;
+        }
+
+        $api       = mc4wp_get_api_v3();
+        $rule_id   = 'wc_coupon_' . $coupon_id;
+        $rule_data = $this->build_rule_data($coupon);
+
+        try {
+            // update existing rule, or create if not found
+            try {
+                $api->update_ecommerce_store_promo_rule($store_id, $rule_id, $rule_data);
+            } catch (MC4WP_API_Resource_Not_Found_Exception $e) {
+                $rule_data['id'] = $rule_id;
+                $api->add_ecommerce_store_promo_rule($store_id, $rule_data);
+            }
+
+            // update or create associated promo code
+            $code_id   = sanitize_title($coupon->get_code());
+            $code_data = $this->build_code_data($coupon);
+
+            try {
+                $api->update_ecommerce_store_promo_rule_promo_code($store_id, $rule_id, $code_id, $code_data);
+            } catch (MC4WP_API_Resource_Not_Found_Exception $e) {
+                $code_data['id'] = $code_id;
+                $api->add_ecommerce_store_promo_rule_promo_code($store_id, $rule_id, $code_data);
+            }
+
+            $log->info(sprintf('Coupon Sync > Successfully synced %s', $coupon->get_code()));
+        } catch (MC4WP_API_Exception $e) {
+            $log->error(sprintf('Coupon Sync > Mailchimp API error: %s', $e->getMessage()));
+        }
+    }
+
+    /**
+     * @param int $coupon_id
+     */
+    public function delete_coupon($coupon_id)
+    {
+        $log      = mc4wp_get_debug_log();
+        $store_id = $this->get_store_id();
+        if (empty($store_id)) {
+            return;
+        }
+
+        $rule_id = 'wc_coupon_' . $coupon_id;
+
+        try {
+            mc4wp_get_api_v3()->delete_ecommerce_store_promo_rule($store_id, $rule_id);
+            $log->info(sprintf('Coupon Sync > Deleted coupon #%d from Mailchimp', $coupon_id));
+        } catch (MC4WP_API_Exception $e) {
+            // rule may not exist in Mailchimp, that's fine
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function get_store_id()
+    {
+        if ($this->store_id !== '') {
+            return $this->store_id;
+        }
+
+        /**
+         * @param string $store_id
+         */
+        $store_id = (string) apply_filters('mc4wp_coupon_sync_store_id', '');
+        if ($store_id !== '') {
+            return $this->cache_store_id($store_id);
+        }
+
+        // MC4WP E-commerce add-on
+        $store_id = (string) get_option('mc4wp_ecommerce_store_id', '');
+        if ($store_id !== '') {
+            return $this->cache_store_id($store_id);
+        }
+
+        // official "Mailchimp for WooCommerce" plugin
+        $mc4wc_options = (array) get_option('mailchimp-woocommerce', []);
+        if (! empty($mc4wc_options['store_id'])) {
+            return $this->cache_store_id((string) $mc4wc_options['store_id']);
+        }
+
+        // previously discovered store
+        $store_id = (string) get_option('mc4wp_coupon_sync_discovered_store_id', '');
+        if ($store_id !== '') {
+            return $this->cache_store_id($store_id);
+        }
+
+        // auto-discover or create via API
+        return $this->discover_or_create_store();
+    }
+
+    /**
+     * @param string $store_id
+     * @return string
+     */
+    private function cache_store_id($store_id)
+    {
+        $this->store_id = $store_id;
+        return $store_id;
+    }
+
+    /**
+     * @return string
+     */
+    private function discover_or_create_store()
+    {
+        $api = mc4wp_get_api_v3();
+
+        try {
+            $response = $api->get_ecommerce_stores();
+        } catch (MC4WP_API_Exception $e) {
+            return '';
+        }
+
+        $site_domain = wp_parse_url(home_url(), PHP_URL_HOST);
+
+        if (! empty($response->stores)) {
+            // single store: use it
+            if (count($response->stores) === 1) {
+                return $this->save_discovered_store_id($response->stores[0]->id);
+            }
+
+            // multiple stores: match by domain
+            foreach ($response->stores as $store) {
+                if (! empty($store->domain) && stripos($site_domain, $store->domain) !== false) {
+                    return $this->save_discovered_store_id($store->id);
+                }
+            }
+        }
+
+        // no match found: create a store
+        return $this->create_store($api, $site_domain);
+    }
+
+    /**
+     * @param string $store_id
+     * @return string
+     */
+    private function save_discovered_store_id($store_id)
+    {
+        update_option('mc4wp_coupon_sync_discovered_store_id', $store_id);
+        return $this->cache_store_id($store_id);
+    }
+
+    /**
+     * @param MC4WP_API_V3 $api
+     * @param string       $site_domain
+     * @return string
+     */
+    private function create_store($api, $site_domain)
+    {
+        $list_id = $this->get_list_id();
+        if (empty($list_id)) {
+            return '';
+        }
+
+        $store_id = 'mc4wp_' . md5($site_domain);
+
+        try {
+            $api->add_ecommerce_store([
+                'id'            => $store_id,
+                'list_id'       => $list_id,
+                'name'          => get_bloginfo('name') ?: $site_domain,
+                'domain'        => $site_domain,
+                'currency_code' => get_woocommerce_currency(),
+                'platform'      => 'woocommerce',
+            ]);
+        } catch (MC4WP_API_Exception $e) {
+            // store may already exist; verify before proceeding
+            try {
+                $api->get_ecommerce_store($store_id);
+            } catch (MC4WP_API_Exception $verify_error) {
+                return '';
+            }
+        }
+
+        return $this->save_discovered_store_id($store_id);
+    }
+
+    /**
+     * @return string
+     */
+    private function get_list_id()
+    {
+        // from WooCommerce integration settings
+        $integration_options = (array) get_option('mc4wp_integrations', []);
+        if (! empty($integration_options['woocommerce']['lists'])) {
+            return (string) reset($integration_options['woocommerce']['lists']);
+        }
+
+        // from the first available Mailchimp list
+        try {
+            $mailchimp = new MC4WP_MailChimp();
+            $lists     = $mailchimp->get_lists();
+            if (! empty($lists)) {
+                return (string) reset($lists)->id;
+            }
+        } catch (Exception $e) {
+            // ignore
+        }
+
+        return '';
+    }
+
+    /**
+     * @param WC_Coupon $coupon
+     * @return array
+     */
+    private function build_rule_data(WC_Coupon $coupon)
+    {
+        $type   = $coupon->get_discount_type();
+        $amount = (float) $coupon->get_amount();
+
+        if ('percent' === $type) {
+            $mc_type   = 'percentage';
+            $mc_target = 'total';
+            $amount    = $amount / 100;
+        } elseif ('fixed_cart' === $type) {
+            $mc_type   = 'fixed';
+            $mc_target = 'total';
+        } else {
+            $mc_type   = 'fixed';
+            $mc_target = 'per_item';
+        }
+
+        $data = [
+            'title'       => $coupon->get_code(),
+            'description' => $coupon->get_description() ?: $coupon->get_code(),
+            'amount'      => $amount,
+            'type'        => $mc_type,
+            'target'      => $mc_target,
+            'enabled'     => 'publish' === get_post_status($coupon->get_id()),
+        ];
+
+        $expiry_date = $coupon->get_date_expires();
+        if ($expiry_date) {
+            $data['expires_at'] = $expiry_date->format('Y-m-d\TH:i:sO');
+        }
+
+        /**
+         * @param array     $data
+         * @param WC_Coupon $coupon
+         */
+        return apply_filters('mc4wp_promo_rule_data', $data, $coupon);
+    }
+
+    /**
+     * @param WC_Coupon $coupon
+     * @return array
+     */
+    private function build_code_data(WC_Coupon $coupon)
+    {
+        $data = [
+            'code'               => strtoupper($coupon->get_code()),
+            'redemption_url'     => esc_url(wc_get_cart_url()),
+            'usage_count'        => (int) $coupon->get_usage_count(),
+            'enabled'            => 'publish' === get_post_status($coupon->get_id()),
+            'created_at_foreign' => gmdate('Y-m-d\TH:i:sO', $coupon->get_date_created() ? $coupon->get_date_created()->getTimestamp() : time()),
+            'updated_at_foreign' => gmdate('Y-m-d\TH:i:sO', $coupon->get_date_modified() ? $coupon->get_date_modified()->getTimestamp() : time()),
+        ];
+
+        /**
+         * @param array     $data
+         * @param WC_Coupon $coupon
+         */
+        return apply_filters('mc4wp_promo_code_data', $data, $coupon);
+    }
+}

--- a/integrations/woocommerce/class-woocommerce.php
+++ b/integrations/woocommerce/class-woocommerce.php
@@ -73,6 +73,11 @@ class MC4WP_WooCommerce_Integration extends MC4WP_Integration
                 return '1';
             });
         }
+
+        if (! empty($this->options['sync_coupons'])) {
+            require_once __DIR__ . '/class-coupon-sync.php';
+            new MC4WP_WooCommerce_Coupon_Sync();
+        }
     }
 
     /**
@@ -83,7 +88,8 @@ class MC4WP_WooCommerce_Integration extends MC4WP_Integration
     protected function get_default_options()
     {
         $defaults             = parent::get_default_options();
-        $defaults['position'] = 'billing';
+        $defaults['position']     = 'billing';
+        $defaults['sync_coupons'] = 0;
         return $defaults;
     }
 


### PR DESCRIPTION
## Summary

Adds automatic WooCommerce coupon synchronization to Mailchimp as Promo Rules & Promo Codes. Users enable a toggle in **MC4WP > Integrations > WooCommerce** — no manual code or configuration needed.

Fixes #813

## Problem

There's no built-in way to sync WooCommerce coupons to Mailchimp promo codes. Users must either manually create them in Mailchimp or write custom integration code.

## Solution

A new `MC4WP_WooCommerce_Coupon_Sync` class hooks into `save_post_shop_coupon` and `woocommerce_delete_coupon` to automatically push coupon data to Mailchimp's E-commerce Promo Rules/Codes API.

The Store ID is resolved via a 6-step cascade: filter override → `mc4wp_ecommerce_store_id` option → official "Mailchimp for WooCommerce" plugin option → cached discovery → API auto-discover by domain → auto-create store. This ensures zero manual configuration for the vast majority of setups.

## Changes

### [NEW] `integrations/woocommerce/class-coupon-sync.php`

Core sync class with:

- **`sync_coupon()`** — Uses update-or-create pattern (try PATCH → catch 404 → POST) for idempotent syncs
- **`delete_coupon()`** — Removes promo rule from Mailchimp on WooCommerce coupon deletion
- **`get_store_id()`** — 6-step cascade for Store ID resolution, including auto-creation via `POST /ecommerce/stores`
- **`build_rule_data()`** / **`build_code_data()`** — Maps WooCommerce coupon types (`percent`, `fixed_cart`, `fixed_product`) to Mailchimp promo rule types
- Filterable via `mc4wp_coupon_sync_store_id`, `mc4wp_promo_rule_data`, `mc4wp_promo_code_data`

### [MODIFY] `integrations/woocommerce/class-woocommerce.php`

```php
// Added default option
$defaults['sync_coupons'] = 0;

// Conditional loading in add_hooks()
if (! empty($this->options['sync_coupons'])) {
    require_once __DIR__ . '/class-coupon-sync.php';
    new MC4WP_WooCommerce_Coupon_Sync();
}
```

### [MODIFY] `integrations/woocommerce/admin-after.php`

Added "Sync Coupons" toggle checkbox to the WooCommerce integration settings page, matching existing UI patterns.

## Testing

**Test 1: Coupon sync**
1. Enable "Sync Coupons" in MC4WP > Integrations > WooCommerce
2. Create/update a WooCommerce coupon
3. Coupon appears in Mailchimp as a Promo Rule + Promo Code

**Test 2: Coupon deletion**
1. Delete a synced coupon in WooCommerce
2. Promo rule is removed from Mailchimp

**Test 3: Store auto-creation**
1. No existing Mailchimp store matching the site domain
2. Sync a coupon — store is auto-created and cached

## Screenshots
<img width="1625" height="820" alt="image" src="https://github.com/user-attachments/assets/58e6dc42-29a7-425f-b5ba-ee5053c01df3" />
.
<img width="1905" height="661" alt="image" src="https://github.com/user-attachments/assets/091d085e-c2ee-4431-ace8-9145de6c527c" />
.
<img width="1509" height="743" alt="image" src="https://github.com/user-attachments/assets/43cb0d02-8288-41ab-ae5e-7a6f4037f693" />
.
<img width="1314" height="938" alt="image" src="https://github.com/user-attachments/assets/4d4cfbe7-8444-45e2-b0e2-13aa8cb9c86d" />

## Plugin build
[mailchimp-for-wp-fix-813.zip](https://github.com/user-attachments/files/27022296/mailchimp-for-wp-fix-813.zip)
