### PR TITLE
i18n: add missing translators comments for placeholder strings

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -425,6 +425,7 @@ class MC4WP_Admin
                 $message = sprintf('<strong>%s</strong> %s %s ', esc_html__('Error connecting to Mailchimp:', 'mailchimp-for-wp'), $e->getCode(), $e->getMessage());
 
                 if (is_object($e->response_data) && ! empty($e->response_data->ref_no)) {
+                    // translators: %s is the Mailchimp firewall reference number.
                     $message .= '<br />' . sprintf(esc_html__('Looks like your server is blocked by Mailchimp\'s firewall. Please contact Mailchimp support and include the following reference number: %s', 'mailchimp-for-wp'), $e->response_data->ref_no);
                 }
 
@@ -508,6 +509,7 @@ class MC4WP_Admin
         }
 
         echo '<div class="notice notice-warning mc4wp-is-dismissible">';
+        // translators: %s is the URL to the plugin settings page.
         echo '<p>', sprintf(wp_kses(__('To get started with Mailchimp for WordPress, please <a href="%s">enter your Mailchimp API key on the settings page of the plugin</a>.', 'mailchimp-for-wp'), ['a' => ['href' => []]]), admin_url('admin.php?page=mailchimp-for-wp')), '</p>';
         echo '<form method="post">';
         wp_nonce_field('_mc4wp_action', '_wpnonce');

--- a/includes/admin/class-ads.php
+++ b/includes/admin/class-ads.php
@@ -53,6 +53,7 @@ class MC4WP_Admin_Ads
         echo '<tr>';
         echo '<td colspan="2">';
         echo '<p class="description">';
+        // translators: %s is a URL to the premium features page.
         echo sprintf(__('Want to customize the style of your form? <a href="%s">Try our Styles Builder</a> & edit the look of your forms with just a few clicks.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=form-settings-link');
         echo '</p>';
         echo '</td>';
@@ -69,8 +70,10 @@ class MC4WP_Admin_Ads
         echo '<p class="description">';
 
         if (rand(1, 2) === 1) {
+            // translators: %s is a URL to the premium features page.
             echo sprintf(__('Be notified whenever someone subscribes? <a href="%s">Mailchimp for WordPress Premium</a> allows you to set up email notifications for your forms.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=footer-link');
         } else {
+            // translators: %s is a URL to the premium features page.
             echo sprintf(__('Increased conversions? <a href="%s">Mailchimp for WordPress Premium</a> submits forms without reloading the entire page, resulting in a much better experience for your visitors.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=form-settings-link');
         }
 
@@ -98,16 +101,19 @@ class MC4WP_Admin_Ads
         if (isset($_GET['view']) && $_GET['view'] === 'edit-form') {
             // WPML & Polylang specific message
             if (defined('ICL_LANGUAGE_CODE')) {
+                // translators: %s is a URL to the premium features page.
                 echo '<p class="description">' . sprintf(__('Do you want translated forms for all of your languages? <a href="%s">Try Mailchimp for WordPress Premium</a>, which does just that plus more.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=footer-link') . '</p>';
                 return;
             }
 
             // General "edit form" message
+            // translators: %s is a URL to the premium features page.
             echo '<p class="description">' . sprintf(__('Do you want to create more than one form? Our Premium add-on does just that! <a href="%s">Have a look at all Premium benefits</a>.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=footer-link') . '</p>';
             return;
         }
 
         // General message
+        // translators: %s is a URL to the premium features page.
         echo '<p class="description">' . sprintf(__('Are you enjoying this plugin? The Premium add-on unlocks several powerful features. <a href="%s">Find out about all benefits now</a>.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=footer-link') . '</p>';
     }
 
@@ -151,6 +157,7 @@ class MC4WP_Admin_Ads
         echo __('Do you want to track all WooCommerce orders in Mailchimp so you can send emails based on the purchase activity of your subscribers?', 'mailchimp-for-wp');
         echo '</p>';
         echo '<p>';
+        // translators: 1: URL to the premium upgrade page, 2: URL to the e-commerce features documentation.
         echo sprintf(__('<a href="%1$s">Upgrade to Mailchimp for WordPress Premium</a> or <a href="%2$s">read more about Mailchimp\'s E-Commerce features</a>.', 'mailchimp-for-wp') . '</p>', 'https://www.mc4wp.com/premium-features/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=other-settings-link', 'https://www.mc4wp.com/kb/what-is-ecommerce360/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=other-settings-link');
         echo '</p>';
         echo '</div>';

--- a/includes/admin/class-review-notice.php
+++ b/includes/admin/class-review-notice.php
@@ -67,6 +67,7 @@ class MC4WP_Admin_Review_Notice
         echo '<div class="notice notice-info mc4wp-is-dismissible" id="mc4wp-review-notice">';
         echo '<p>';
         echo esc_html__('You\'ve been using Mailchimp for WordPress for some time now; we hope you love it!', 'mailchimp-for-wp'), ' <br />';
+        // translators: %s is the URL to the WordPress.org plugin review page.
         echo sprintf(wp_kses(__('If you do, please <a href="%s">leave us a 5★ rating on WordPress.org</a>. It would be of great help to us.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://wordpress.org/support/view/plugin-reviews/mailchimp-for-wp?rate=5#new-post');
         echo '</p>';
         echo '<form method="POST" id="mc4wp-dismiss-review-form"><button type="submit" class="notice-dismiss"><span class="screen-reader-text">', esc_html__('Dismiss this notice.', 'mailchimp-for-wp'), '</span></button><input type="hidden" name="_mc4wp_action" value="dismiss_review_notice" />', wp_nonce_field('_mc4wp_action', '_wpnonce', true, false), '</form>';

--- a/includes/campaigns/class-archive.php
+++ b/includes/campaigns/class-archive.php
@@ -135,8 +135,8 @@ class MC4WP_Campaign_Archive
                 $timestamp = strtotime($campaign->send_time);
                 if ($timestamp) {
                     $html .= ' <span class="mc4wp-campaign-archive__date">';
-                    /* translators: %s: Campaign send date. */
                     $html .= sprintf(
+                        // translators: %s is the campaign send date.
                         esc_html__('(%s)', 'mailchimp-for-wp'),
                         esc_html(date_i18n(get_option('date_format'), $timestamp))
                     );

--- a/includes/class-dynamic-content-tags.php
+++ b/includes/class-dynamic-content-tags.php
@@ -46,21 +46,25 @@ abstract class MC4WP_Dynamic_Content_Tags
         ];
 
         $this->tags['date'] = [
+        // translators: %s is an example of the current date, e.g. 2024/01/15.
         'description' => sprintf(__('The current date. Example: %s.', 'mailchimp-for-wp'), '<strong>' . gmdate('Y/m/d', time() + ( get_option('gmt_offset') * HOUR_IN_SECONDS )) . '</strong>'),
         'replacement' => gmdate('Y/m/d', time() + ( get_option('gmt_offset') * HOUR_IN_SECONDS )),
         ];
 
         $this->tags['time'] = [
+        // translators: %s is an example of the current time, e.g. 14:30:00.
         'description' => sprintf(__('The current time. Example: %s.', 'mailchimp-for-wp'), '<strong>' . gmdate('H:i:s', time() + ( get_option('gmt_offset') * HOUR_IN_SECONDS )) . '</strong>'),
         'replacement' => gmdate('H:i:s', time() + ( get_option('gmt_offset') * HOUR_IN_SECONDS )),
         ];
 
         $this->tags['language'] = [
+        // translators: %s is an example of the site's locale, e.g. en_US.
         'description' => sprintf(__('The site\'s language. Example: %s.', 'mailchimp-for-wp'), '<strong>' . get_locale() . '</strong>'),
         'callback'    => 'get_locale',
         ];
 
         $this->tags['ip'] = [
+        // translators: %s is an example of the visitor's IP address.
         'description' => sprintf(__('The visitor\'s IP address. Example: %s.', 'mailchimp-for-wp'), '<strong>' . mc4wp_get_request_ip_address() . '</strong>'),
         'callback'    => 'mc4wp_get_request_ip_address',
         ];

--- a/includes/forms/class-asset-manager.php
+++ b/includes/forms/class-asset-manager.php
@@ -201,6 +201,7 @@ class MC4WP_Form_Asset_Manager
         if ($this->load_typo_checker) {
             wp_enqueue_script('mc4wp-email-typo-checker');
             wp_localize_script('mc4wp-email-typo-checker', 'mc4wp_email_typo_checker', [
+                // translators: %s is the suggested correct email address.
                 'suggestion_text' => __('Did you mean %s?', 'mailchimp-for-wp'),
                 'domains'         => apply_filters('mc4wp_email_typo_checker_domains', [
                     'gmail.com',

--- a/includes/forms/class-form.php
+++ b/includes/forms/class-form.php
@@ -24,6 +24,7 @@ class MC4WP_Form
      */
     public static function throw_not_found_exception($post_id)
     {
+        // translators: %d is the form post ID.
         $message = sprintf(__('There is no form with ID %d, perhaps it was deleted?', 'mailchimp-for-wp'), $post_id);
         throw new Exception($message);
     }

--- a/includes/forms/class-widget.php
+++ b/includes/forms/class-widget.php
@@ -96,7 +96,10 @@ class MC4WP_Form_Widget extends WP_Widget
         ?>
 
         <p class="description">
-            <?php printf(__('You can edit your sign-up form in the <a href="%s">Mailchimp for WordPress form settings</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=mailchimp-for-wp-forms')); ?>
+            <?php
+            // translators: %s is the URL to the plugin form settings page.
+            printf(__('You can edit your sign-up form in the <a href="%s">Mailchimp for WordPress form settings</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=mailchimp-for-wp-forms'));
+            ?>
         </p>
         <?php
     }

--- a/includes/forms/views/add-form.php
+++ b/includes/forms/views/add-form.php
@@ -46,7 +46,10 @@
                         } else {
                             ?>
                         <p class="mc4wp-notice">
-                            <?php echo sprintf(wp_kses(__('No Mailchimp audiences found. Did you <a href="%s">connect with Mailchimp</a>?', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), admin_url('admin.php?page=mailchimp-for-wp')); ?>
+                            <?php
+                            // translators: %s is the URL to the Mailchimp for WordPress settings page.
+                            echo sprintf(wp_kses(__('No Mailchimp audiences found. Did you <a href="%s">connect with Mailchimp</a>?', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), admin_url('admin.php?page=mailchimp-for-wp'));
+                            ?>
                         </p>
                             <?php
                         }

--- a/includes/forms/views/edit-form.php
+++ b/includes/forms/views/edit-form.php
@@ -55,7 +55,10 @@ $tabs = apply_filters('mc4wp_admin_edit_form_tabs', $tabs);
                             style="line-height: initial;">
                 </div>
                 <div>
-                    <?php echo sprintf(esc_html__('Use the shortcode %s to display this form inside a post, page or text widget.', 'mailchimp-for-wp'), '<input type="text" onfocus="this.select();" readonly="readonly" value="' . esc_attr(sprintf('[mc4wp_form id=%d]', $form->ID)) . '" size="' . ( strlen($form->ID) + 15 ) . '">'); ?>
+                    <?php
+                    // translators: %s is the shortcode to display the form (e.g. [mc4wp_form id=123]).
+                    echo sprintf(esc_html__('Use the shortcode %s to display this form inside a post, page or text widget.', 'mailchimp-for-wp'), '<input type="text" onfocus="this.select();" readonly="readonly" value="' . esc_attr(sprintf('[mc4wp_form id=%d]', $form->ID)) . '" size="' . ( strlen($form->ID) + 15 ) . '">');
+                    ?>
                 </div>
             </div>
 

--- a/includes/forms/views/parts/dynamic-content-tags.php
+++ b/includes/forms/views/parts/dynamic-content-tags.php
@@ -5,7 +5,10 @@ $tags = mc4wp('forms')->get_tags();
 ?>
 <h2><?php echo esc_html__('Add dynamic form variable', 'mailchimp-for-wp'); ?></h2>
 <p>
-    <?php echo sprintf(wp_kses(__('The following list of variables can be used to <a href="%s">add some dynamic content to your form or success and error messages</a>.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://www.mc4wp.com/kb/using-variables-in-your-form-or-messages/') . ' ' . __('This allows you to personalise your form or response messages.', 'mailchimp-for-wp'); ?>
+    <?php
+    // translators: %s is a URL to the documentation on using dynamic variables in forms.
+    echo sprintf(wp_kses(__('The following list of variables can be used to <a href="%s">add some dynamic content to your form or success and error messages</a>.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://www.mc4wp.com/kb/using-variables-in-your-form-or-messages/') . ' ' . __('This allows you to personalise your form or response messages.', 'mailchimp-for-wp');
+    ?>
 </p>
 <table class="widefat striped">
     <?php

--- a/includes/forms/views/tabs/form-appearance.php
+++ b/includes/forms/views/tabs/form-appearance.php
@@ -2,6 +2,7 @@
 
 $theme       = wp_get_theme();
 $css_options = [
+    // translators: %s is the name of the active WordPress theme.
     '0'                                     => sprintf(esc_html__('Inherit from %s theme', 'mailchimp-for-wp'), $theme->Name), // @phpstan-ignore-line WP_Theme::$name is a dynamic property
     'basic'                                 => esc_html__('Basic', 'mailchimp-for-wp'),
     esc_html__('Form Themes', 'mailchimp-for-wp') => [

--- a/includes/forms/views/tabs/form-fields.php
+++ b/includes/forms/views/tabs/form-fields.php
@@ -36,7 +36,10 @@
 
 <?php submit_button(); ?>
 
-<p class="mc4wp-form-usage"><?php printf(esc_html__('Use the shortcode %s to display this form inside a post, page or text widget.', 'mailchimp-for-wp'), '<input type="text" onfocus="this.select();" readonly="readonly" value="' . esc_attr(sprintf('[mc4wp_form id=%d]', $form->ID)) . '" size="' . ( strlen($form->ID) + 15 ) . '">'); ?></p>
+<p class="mc4wp-form-usage"><?php
+    // translators: %s is the shortcode to display the form (e.g. [mc4wp_form id=123]).
+    printf(esc_html__('Use the shortcode %s to display this form inside a post, page or text widget.', 'mailchimp-for-wp'), '<input type="text" onfocus="this.select();" readonly="readonly" value="' . esc_attr(sprintf('[mc4wp_form id=%d]', $form->ID)) . '" size="' . ( strlen($form->ID) + 15 ) . '">');
+?></p>
 
 
 <?php // Content for Thickboxes ?>

--- a/includes/forms/views/tabs/form-messages.php
+++ b/includes/forms/views/tabs/form-messages.php
@@ -93,7 +93,10 @@
     <tr valign="top">
         <th></th>
         <td>
-            <p class="description"><?php echo sprintf(esc_html__('HTML tags like %s are allowed in the message fields.', 'mailchimp-for-wp'), '<code>' . esc_html('<strong><em><a>') . '</code>'); ?></p>
+            <p class="description"><?php
+                // translators: %s is a list of allowed HTML tags (e.g. <strong><em><a>).
+                echo sprintf(esc_html__('HTML tags like %s are allowed in the message fields.', 'mailchimp-for-wp'), '<code>' . esc_html('<strong><em><a>') . '</code>');
+            ?></p>
         </td>
     </tr>
 

--- a/includes/forms/views/tabs/form-settings.php
+++ b/includes/forms/views/tabs/form-settings.php
@@ -14,7 +14,10 @@
         // loop through lists
         if (empty($lists)) {
             ?>
-            <td colspan="2"><?php echo sprintf(wp_kses(__('No audiences found, <a href="%s">are you connected to Mailchimp</a>?', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), admin_url('admin.php?page=mailchimp-for-wp')); ?></td>
+            <td colspan="2"><?php
+                // translators: %s is the URL to the Mailchimp for WordPress settings page.
+                echo sprintf(wp_kses(__('No audiences found, <a href="%s">are you connected to Mailchimp</a>?', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), admin_url('admin.php?page=mailchimp-for-wp'));
+            ?></td>
             <?php
         } else {
             ?>
@@ -164,6 +167,7 @@
     <tr valign="top">
         <th scope="row"><label for="mc4wp_form_redirect"><?php echo esc_html__('Redirect to URL after successful sign-ups', 'mailchimp-for-wp'); ?></label></th>
         <td>
+            <?php // translators: %s is an example URL, e.g. https://example.com/thank-you/. ?>
             <input type="text" class="widefat" name="mc4wp_form[settings][redirect]" id="mc4wp_form_redirect" placeholder="<?php echo sprintf(esc_attr__('Example: %s', 'mailchimp-for-wp'), esc_attr(site_url('/thank-you/'))); ?>" value="<?php echo esc_attr($opts['redirect']); ?>" />
             <p class="description">
                 <?php echo wp_kses(__('Leave empty or enter <code>0</code> for no redirect. Otherwise, use complete (absolute) URLs, including <code>http://</code>.', 'mailchimp-for-wp'), [ 'code' => [] ]); ?>

--- a/includes/integrations/views/integration-settings.php
+++ b/includes/integrations/views/integration-settings.php
@@ -12,7 +12,10 @@
     <div class="mc4wp-row">
         <div class="main-content mc4wp-col">
             <h1 class="mc4wp-page-title">
-                <?php printf(esc_html__('%s integration', 'mailchimp-for-wp'), esc_html($integration->name)); ?>
+                <?php
+                // translators: %s is the name of the integration (e.g. Contact Form 7, WooCommerce).
+                printf(esc_html__('%s integration', 'mailchimp-for-wp'), esc_html($integration->name));
+                ?>
             </h1>
 
             <h2 style="display: none;"></h2>
@@ -20,7 +23,10 @@
 
             <div id="notice-additional-fields" class="notice notice-warning" style="display: none;">
                 <p><?php echo esc_html__('The selected Mailchimp audience requires custom fields, which may prevent this integration from working.', 'mailchimp-for-wp'); ?></p>
-                <p><?php echo sprintf(wp_kses(__('Please ensure you <a href="%1$s">configure the plugin to send all required fields</a> or <a href="%2$s">log into your Mailchimp account</a> and make sure only the email & name fields are marked as required fields for the selected audiences.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://www.mc4wp.com/kb/send-additional-fields-from-integrations/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=integrations-page', 'https://admin.mailchimp.com/lists/'); ?></p>
+                <p><?php
+                    // translators: 1: URL to the MC4WP documentation on sending additional fields, 2: URL to the Mailchimp audience settings page.
+                    echo sprintf(wp_kses(__('Please ensure you <a href="%1$s">configure the plugin to send all required fields</a> or <a href="%2$s">log into your Mailchimp account</a> and make sure only the email & name fields are marked as required fields for the selected audiences.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://www.mc4wp.com/kb/send-additional-fields-from-integrations/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=integrations-page', 'https://admin.mailchimp.com/lists/');
+                ?></p>
             </div>
 
             <p>
@@ -45,7 +51,10 @@
                             <td class="nowrap integration-toggles-wrap">
                                 <label><input type="radio" name="mc4wp_integrations[<?php echo $integration->slug; ?>][enabled]" value="1" <?php checked($opts['enabled'], 1); ?> /> <?php echo esc_html__('Yes', 'mailchimp-for-wp'); ?></label> &nbsp;
                                 <label><input type="radio" name="mc4wp_integrations[<?php echo $integration->slug; ?>][enabled]" value="0" <?php checked($opts['enabled'], 0); ?> /> <?php echo esc_html__('No', 'mailchimp-for-wp'); ?></label>
-                                <p class="description"><?php echo sprintf(esc_html__('Enable the %s integration? This will add a sign-up checkbox to the form.', 'mailchimp-for-wp'), $integration->name); ?></p>
+                                <p class="description"><?php
+                                    // translators: %s is the name of the integration (e.g. Contact Form 7, WooCommerce).
+                                    echo sprintf(esc_html__('Enable the %s integration? This will add a sign-up checkbox to the form.', 'mailchimp-for-wp'), $integration->name);
+                                ?></p>
                             </td>
                         </tr>
                         </tbody>
@@ -78,6 +87,7 @@
 
                                     echo sprintf(
                                         wp_kses(
+                                            // translators: %s is a URL to the GDPR compliance documentation.
                                             __('<strong>Warning: </strong> enabling this may affect your <a href="%s">GDPR compliance</a>.', 'mailchimp-for-wp'),
                                             [
                                             'a' => [ 'href' => [] ],
@@ -120,7 +130,10 @@
                                 echo '</p>';
                                 echo '</td>';
                             } else {
-                                echo '<td>', sprintf(wp_kses(__('No audiences found, <a href="%s">are you connected to Mailchimp</a>?', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), esc_url(admin_url('admin.php?page=mailchimp-for-wp'))), '</td>';
+                                echo '<td>';
+                                // translators: %s is the URL to the Mailchimp for WordPress settings page.
+                                echo sprintf(wp_kses(__('No audiences found, <a href="%s">are you connected to Mailchimp</a>?', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), esc_url(admin_url('admin.php?page=mailchimp-for-wp')));
+                                echo '</td>';
                             }
                             ?>
                         </tr>
@@ -139,7 +152,10 @@
                             <th scope="row"><label for="mc4wp_checkbox_label"><?php echo esc_html__('Checkbox label text', 'mailchimp-for-wp'); ?></label></th>
                             <td>
                                 <input type="text"  class="widefat" id="mc4wp_checkbox_label" name="mc4wp_integrations[<?php echo $integration->slug; ?>][label]" value="<?php echo esc_attr($opts['label']); ?>" required />
-                                <p class="description"><?php printf(esc_html__('HTML tags like %s are allowed in the label text.', 'mailchimp-for-wp'), '<code>' . esc_html('<strong><em><a>') . '</code>'); ?></p>
+                                <p class="description"><?php
+                                    // translators: %s is a list of allowed HTML tags (e.g. <strong><em><a>).
+                                    printf(esc_html__('HTML tags like %s are allowed in the label text.', 'mailchimp-for-wp'), '<code>' . esc_html('<strong><em><a>') . '</code>');
+                                ?></p>
                             </td>
                         </tr>
                         <?php
@@ -165,6 +181,7 @@
                                     echo '<br />';
                                     echo sprintf(
                                         wp_kses(
+                                            // translators: %s is a URL to the GDPR compliance documentation.
                                             __('<strong>Warning: </strong> enabling this may affect your <a href="%s">GDPR compliance</a>.', 'mailchimp-for-wp'),
                                             [
                                                     'a'      => [ 'href' => [] ],

--- a/includes/views/other-settings.php
+++ b/includes/views/other-settings.php
@@ -42,7 +42,10 @@ defined('ABSPATH') or exit;
                                     <option value="debug" <?php selected('debug', $opts['debug_log_level']); ?>><?php echo esc_html__('Everything', 'mailchimp-for-wp'); ?></option>
                                 </select>
                                 <p class="description">
-                                    <?php echo sprintf(wp_kses(__('Determines what events should be written to <a href="%s">the debug log</a> (see below).', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://www.mc4wp.com/kb/how-to-enable-log-debugging/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=settings-page'); ?>
+                                    <?php
+                                    // translators: %s is a URL to the debug log documentation.
+                                    echo sprintf(wp_kses(__('Determines what events should be written to <a href="%s">the debug log</a> (see below).', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://www.mc4wp.com/kb/how-to-enable-log-debugging/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=settings-page');
+                                    ?>
                                 </p>
                             </td>
                         </tr>
@@ -92,6 +95,7 @@ defined('ABSPATH') or exit;
                 if (! $log->test()) {
                     echo '<p>';
                     echo esc_html__('Log file is not writable.', 'mailchimp-for-wp') . ' ';
+                    // translators: 1: the log file path, 2: URL to the WordPress file permissions documentation.
                     echo sprintf(wp_kses(__('Please ensure %1$s has the proper <a href="%2$s">file permissions</a>.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), '<code>' . $log->file . '</code>', 'https://codex.wordpress.org/Changing_File_Permissions');
                     echo '</p>';
 

--- a/includes/views/parts/admin-sidebar.php
+++ b/includes/views/parts/admin-sidebar.php
@@ -15,7 +15,9 @@ function _mc4wp_admin_sidebar_support_notice()
             <li><a href="https://www.mc4wp.com/kb/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=sidebar"><?php echo esc_html__('Knowledge Base', 'mailchimp-for-wp'); ?></a></li>
             <li><a href="https://wordpress.org/plugins/mailchimp-for-wp/faq/"><?php echo esc_html__('Frequently Asked Questions', 'mailchimp-for-wp'); ?></a></li>
         </ul>
+        <?php // translators: %s is the URL to the WordPress.org support forum for this plugin. ?>
         <p><?php echo sprintf(wp_kses(__('If your answer can not be found in the resources listed above, please use the <a href="%s">support forums on WordPress.org</a>.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://wordpress.org/support/plugin/mailchimp-for-wp'); ?></p>
+        <?php // translators: %s is the URL to the GitHub issues page. ?>
         <p><?php echo sprintf(wp_kses(__('Found a bug? Please <a href="%s">open an issue on GitHub</a>.', 'mailchimp-for-wp'), [ 'a' => [ 'href' => [] ] ]), 'https://github.com/ibericode/mailchimp-for-wordpress/issues'); ?></p>
     </div>
     <?php

--- a/includes/views/parts/lists-overview.php
+++ b/includes/views/parts/lists-overview.php
@@ -18,6 +18,7 @@
         <p><?php echo esc_html__('No audiences were found in your Mailchimp account', 'mailchimp-for-wp'); ?>.</p>
         <?php
     } else {
+        // translators: %d is the number of Mailchimp audiences found.
         echo '<p>', sprintf(esc_html__('A total of %d audiences were found in your Mailchimp account.', 'mailchimp-for-wp'), count($lists)), '</p>';
         echo '<table class="widefat striped" id="mc4wp-mailchimp-lists-overview">';
 

--- a/integrations/contact-form-7/admin-before.php
+++ b/integrations/contact-form-7/admin-before.php
@@ -1,3 +1,6 @@
 <p>
-    <?php printf(__('To integrate with Contact Form 7, configure the settings below and then add %s to your CF7 form mark-up.', 'mailchimp-for-wp'), '<input type="text" onfocus="this.select()" readonly value="' . esc_attr('[mc4wp_checkbox]') . '">'); ?>
+    <?php
+    // translators: %s is the shortcode input element [mc4wp_checkbox].
+    printf(__('To integrate with Contact Form 7, configure the settings below and then add %s to your CF7 form mark-up.', 'mailchimp-for-wp'), '<input type="text" onfocus="this.select()" readonly value="' . esc_attr('[mc4wp_checkbox]') . '">');
+    ?>
 </p>

--- a/integrations/gravity-forms/class-gravity-forms.php
+++ b/integrations/gravity-forms/class-gravity-forms.php
@@ -140,6 +140,7 @@ class MC4WP_Gravity_Forms_Integration extends MC4WP_Integration
                 <?php
                 _e('Select "yes" if the checkbox should be pre-checked.', 'mailchimp-for-wp');
                 echo '<br />';
+                // translators: %s is the URL to the GDPR compliance documentation.
                 printf(__('<strong>Warning: </strong> enabling this may affect your <a href="%s">GDPR compliance</a>.', 'mailchimp-for-wp'), 'https://www.mc4wp.com/kb/gdpr-compliance/#utm_source=wp-plugin&utm_medium=mailchimp-for-wp&utm_campaign=integrations-page');
                 ?>
             </p>

--- a/integrations/ninja-forms/admin-before.php
+++ b/integrations/ninja-forms/admin-before.php
@@ -1,3 +1,6 @@
 <p>
-    <?php echo sprintf(__('To integrate with Ninja Forms, add the "Mailchimp" action to <a href="%s">one of your Ninja Forms forms</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=ninja-forms')); ?>
+    <?php
+    // translators: %s is the URL to the Ninja Forms admin page.
+    echo sprintf(__('To integrate with Ninja Forms, add the "Mailchimp" action to <a href="%s">one of your Ninja Forms forms</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=ninja-forms'));
+    ?>
 </p>

--- a/integrations/prosopo-procaptcha/admin-before.php
+++ b/integrations/prosopo-procaptcha/admin-before.php
@@ -1,7 +1,7 @@
 <?php
 
-// translators: %1$s is opening anchor tag, %2$s is closing anchor tag
 echo sprintf(
+    // translators: %1$s is opening anchor tag, %2$s is closing anchor tag.
     esc_html__(
         '%1$s Procaptcha (by Prosopo) %2$s is offering seamless bot protection without compromising user data. You can customize settings and algorithms, ensuring optimal defense against all types of malicious bots.',
         'mailchimp-for-wp'

--- a/integrations/woocommerce/class-woocommerce.php
+++ b/integrations/woocommerce/class-woocommerce.php
@@ -249,6 +249,7 @@ class MC4WP_WooCommerce_Integration extends MC4WP_Integration
      */
     public function get_object_link($object_id)
     {
+        // translators: %d is the WooCommerce order number.
         return sprintf('<a href="%s">%s</a>', get_edit_post_link($object_id), sprintf(__('Order #%d', 'mailchimp-for-wp'), $object_id));
     }
 }

--- a/integrations/wpforms/admin-before.php
+++ b/integrations/wpforms/admin-before.php
@@ -1,3 +1,6 @@
 <p>
-    <?php printf(__('Use this integration by adding the "Mailchimp" field to <a href="%s">your WPForms forms</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=wpforms-overview')); ?>
+    <?php
+    // translators: %s is the URL to the WPForms overview page.
+    printf(__('Use this integration by adding the "Mailchimp" field to <a href="%s">your WPForms forms</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=wpforms-overview'));
+    ?>
 </p>

--- a/integrations/wpforms/class-field.php
+++ b/integrations/wpforms/class-field.php
@@ -222,6 +222,7 @@ class MC4WP_WPForms_Field extends WPForms_Field
         // Dynamic population is enabled and contains more than 20 items
         if (isset($total) && $total > 20) {
             echo '<div class="wpforms-alert-dynamic wpforms-alert wpforms-alert-warning">';
+            // translators: %d is the total number of choices available.
             printf(__('Showing the first 20 choices.<br> All %d choices will be displayed when viewing the form.', 'wpforms'), absint($total));
             echo '</div>';
         }


### PR DESCRIPTION
## Summary

Adds `// translators:` comments above every i18n function call containing printf-style placeholders (`%s`, `%d`, `%1$s`, etc.), resolving all `WordPress.WP.I18n.MissingTranslatorsComment` PHPCS errors across 19 files in `includes/`.

No functional changes — comment-only additions so translators understand what each placeholder represents.

## Changes

38 missing comments added across admin, forms, integrations, campaigns, and views. Representative example:

### class-widget.php

**Before:**
```php
printf(__('You can edit your sign-up form in the <a href="%s">Mailchimp for WordPress form settings</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=mailchimp-for-wp-forms'));
```

**After:**
```php
// translators: %s is the URL to the plugin form settings page.
printf(__('You can edit your sign-up form in the <a href="%s">Mailchimp for WordPress form settings</a>.', 'mailchimp-for-wp'), admin_url('admin.php?page=mailchimp-for-wp-forms'));
```

**Why:** WordPress i18n handbook requires a `translators:` comment immediately before any i18n call with placeholders, giving translators context about what each placeholder represents.

## Testing

```bash
phpcs --standard=WordPress --sniffs=WordPress.WP.I18n -n \
  --report=csv -d memory_limit=1024M includes/ 2>/dev/null \
  | grep MissingTranslatorsComment
```

Result: 0 errors (was 38).