### PR TITLE
fix: allow Premium users to use tracking pixel subscriber identify

### DIFF
--- a/includes/class-tracking-pixel.php
+++ b/includes/class-tracking-pixel.php
@@ -46,11 +46,19 @@ class MC4WP_Tracking_Pixel
     /**
      * Output the Mailchimp Site Tracking Pixel SDK script tag.
      *
+     * Skips output when Premium E-Commerce is already loading the script,
+     * to avoid injecting it twice.
+     *
      * @return void
      */
     public function output_tracking_script(): void
     {
         if (empty($this->site_id)) {
+            return;
+        }
+
+        // If Premium E-Commerce is already loading the mcjs script, skip to avoid duplicates.
+        if (self::is_premium_ecommerce_pixel_active()) {
             return;
         }
 
@@ -62,7 +70,13 @@ class MC4WP_Tracking_Pixel
             // BC: support legacy tracking_pixel_id for users who configured it before this auto-connect feature
             $url = sprintf('https://chimpstatic.com/mcjs-connected/js/users/%s.js', $opts['tracking_pixel_id']);
         } else {
-            return;
+            // Try to reuse the script URL from Premium E-Commerce settings
+            $ecommerce_settings = get_option('mc4wp_ecommerce', []);
+            if (! empty($ecommerce_settings['mcjs_url'])) {
+                $url = $ecommerce_settings['mcjs_url'];
+            } else {
+                return;
+            }
         }
 
         wp_enqueue_script('mc4wp-mailchimp-site-tracking-pixel', $url, [], MC4WP_VERSION, [

--- a/includes/views/other-settings.php
+++ b/includes/views/other-settings.php
@@ -65,14 +65,6 @@ defined('ABSPATH') or exit;
 
                 <div class="mc4wp-margin-m">
                     <h3><?php echo esc_html__('Site Tracking Pixel', 'mailchimp-for-wp'); ?></h3>
-                    <?php if (MC4WP_Tracking_Pixel::is_premium_ecommerce_pixel_active()) : ?>
-                        <p class="description">
-                            <?php echo wp_kses(
-                                __('<strong>Note:</strong> Site tracking is currently managed by the <strong>MC4WP Premium E-Commerce</strong> integration. You do not need to configure it here.', 'mailchimp-for-wp'),
-                                ['strong' => []]
-                            ); ?>
-                        </p>
-                    <?php else : ?>
                     <table class="form-table">
                         <tr>
                             <th><label for="mc4wp-tracking-pixel-enabled"><?php echo esc_html__('Enable Site Tracking', 'mailchimp-for-wp'); ?></label></th>
@@ -85,6 +77,14 @@ defined('ABSPATH') or exit;
                                     <?php echo esc_html__('When enabled, the plugin automatically finds or registers your site in Mailchimp and loads the tracking script. Subscribers who sign up via your forms will be automatically identified.', 'mailchimp-for-wp'); ?>
                                     <a href="https://mailchimp.com/help/mailchimp-site-tracking-pixel-integration-guidance/" target="_blank"><?php echo esc_html__('Learn more.', 'mailchimp-for-wp'); ?></a>
                                 </p>
+                                <?php if (MC4WP_Tracking_Pixel::is_premium_ecommerce_pixel_active()) : ?>
+                                <p class="description">
+                                    <?php echo wp_kses(
+                                        __('<strong>Note:</strong> The tracking script is already being loaded by the <strong>MC4WP Premium E-Commerce</strong> integration. Enabling this setting will still identify subscribers after form sign-ups, but will not load a duplicate tracking script.', 'mailchimp-for-wp'),
+                                        ['strong' => []]
+                                    ); ?>
+                                </p>
+                                <?php endif; ?>
                                 <?php if (! empty($opts['tracking_pixel_site_id'])) : ?>
                                     <p class="description">
                                         <strong><?php echo esc_html__('Connected Site ID:', 'mailchimp-for-wp'); ?></strong>
@@ -96,7 +96,6 @@ defined('ABSPATH') or exit;
                             </td>
                         </tr>
                     </table>
-                    <?php endif; ?>
                 </div>
 
 

--- a/mailchimp-for-wp.php
+++ b/mailchimp-for-wp.php
@@ -101,7 +101,6 @@ add_action('plugins_loaded', function () {
         if (
             (! empty($opts['tracking_pixel_enabled']) || ! empty($opts['tracking_pixel_id']))
             && ! empty($site_id)
-            && ! MC4WP_Tracking_Pixel::is_premium_ecommerce_pixel_active()
         ) {
             $tracking_pixel = new MC4WP_Tracking_Pixel($site_id);
             $tracking_pixel->add_hooks();


### PR DESCRIPTION
Follow-up to #832. Fixes the issue where Premium E-Commerce users were locked out of the tracking pixel feature entirely.

The `is_premium_ecommerce_pixel_active()` guard has been moved from the bootstrap (where it blocked class instantiation) into `output_tracking_script()` (where it only prevents a duplicate script tag). Premium users can now use the auto-connect flow, the subscriber identify call, and see the settings UI.

Also reads `mc4wp_ecommerce['mcjs_url']` as a fallback script URL source so both integrations can share the same connected site without redundant API calls.