### PR TITLE
Fix async integrations losing runtime options

### DIFF
--- a/includes/integrations/class-integration.php
+++ b/includes/integrations/class-integration.php
@@ -429,6 +429,11 @@ abstract class MC4WP_Integration
             'list_ids'          => $list_ids,
             'ip_signup'         => mc4wp_get_request_ip_address(),
             'email_type'        => mc4wp_get_email_type(),
+            'options'           => [
+                'double_optin'      => $this->options['double_optin'],
+                'update_existing'   => $this->options['update_existing'],
+                'replace_interests' => $this->options['replace_interests'],
+            ],
         ];
 
         if (function_exists('as_enqueue_async_action')) {
@@ -453,6 +458,11 @@ abstract class MC4WP_Integration
         $list_ids          = $args['list_ids'];
         $email_type        = $args['email_type'];
         $ip_signup         = $args['ip_signup'];
+        $options           = $this->options;
+
+        if (! empty($args['options']) && is_array($args['options'])) {
+            $options = array_merge($options, $args['options']);
+        }
 
         $integration = $this;
         $slug        = $this->slug;
@@ -469,7 +479,7 @@ abstract class MC4WP_Integration
         $map = $mapper->map();
 
         foreach ($map as $list_id => $subscriber) {
-            $subscriber->status     = $this->options['double_optin'] ? 'pending' : 'subscribed';
+            $subscriber->status     = $options['double_optin'] ? 'pending' : 'subscribed';
             $subscriber->email_type = $email_type;
             $subscriber->ip_signup  = $ip_signup;
 
@@ -502,7 +512,7 @@ abstract class MC4WP_Integration
                 continue;
             }
 
-            $result = $mailchimp->list_subscribe($list_id, $subscriber->email_address, $subscriber->to_array(), $this->options['update_existing'], $this->options['replace_interests']);
+            $result = $mailchimp->list_subscribe($list_id, $subscriber->email_address, $subscriber->to_array(), $options['update_existing'], $options['replace_interests']);
         }
 
         // if result failed, show error message

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -42,4 +42,55 @@ class IntegrationTest extends TestCase
         $_POST[ '_mc4wp_subscribe_' . $slug ] = 1;
         self::assertTrue($instance->checkbox_was_checked());
     }
+
+    /**
+     * @covers MC4WP_Integration::subscribe
+     */
+    public function test_subscribe_queues_runtime_options()
+    {
+        global $mock_scheduled_events;
+        $mock_scheduled_events = [];
+
+        $instance = new class ('my-integration', [
+            'double_optin'      => 0,
+            'update_existing'   => 1,
+            'replace_interests' => 1,
+            'lists'             => [ 'abc123' ],
+        ]) extends MC4WP_Sample_Integration {
+            public function subscribe_public(array $data, $related_object_id = 0)
+            {
+                return $this->subscribe($data, $related_object_id);
+            }
+
+            protected function get_log()
+            {
+                return new class {
+                    public function warning($message)
+                    {
+                    }
+
+                    public function error($message)
+                    {
+                    }
+
+                    public function info($message)
+                    {
+                    }
+                };
+            }
+        };
+
+        self::assertTrue($instance->subscribe_public([ 'EMAIL' => 'test@example.com' ], 42));
+        self::assertCount(1, $mock_scheduled_events);
+        self::assertEquals('mc4wp_integration_subscribe', $mock_scheduled_events[0]['hook']);
+
+        $args = $mock_scheduled_events[0]['args'][0];
+
+        self::assertEquals('my-integration', $args['integration_slug']);
+        self::assertEquals(42, $args['related_object_id']);
+        self::assertEquals([ 'abc123' ], $args['list_ids']);
+        self::assertSame(0, $args['options']['double_optin']);
+        self::assertSame(1, $args['options']['update_existing']);
+        self::assertSame(1, $args['options']['replace_interests']);
+    }
 }

--- a/tests/mock.php
+++ b/tests/mock.php
@@ -238,6 +238,25 @@ function wp_next_scheduled($hook, $args = [])
 
 /**
  * @ignore
+ * @var array
+ */
+$mock_scheduled_events = [];
+
+/** @ignore */
+function wp_schedule_single_event($timestamp, $hook, $args = [])
+{
+    global $mock_scheduled_events;
+    $mock_scheduled_events[] = [
+        'timestamp' => $timestamp,
+        'hook'      => $hook,
+        'args'      => $args,
+    ];
+
+    return true;
+}
+
+/**
+ * @ignore
  * @var bool
  */
 $mock_current_user_can = true;


### PR DESCRIPTION
## Summary

This preserves runtime integration options when integration signups are queued for async processing.

The async integration flow currently queues the subscriber data and list IDs, then processes the signup later. For integrations that apply per-submission or per-action options at runtime, such as Ninja Forms, the background job no longer has access to those runtime options and falls back to the integration defaults.

That means a Ninja Forms action with double opt-in disabled can still send `status: pending` to Mailchimp.

## Changes

- Include `double_optin`, `update_existing`, and `replace_interests` in the queued integration signup args.
- Merge queued options back into the integration options when processing the background signup.
- Use the preserved options when setting subscriber status and calling `list_subscribe()`.
- Add a regression test covering the queued runtime options.

## Testing

```bash
vendor/bin/phpunit tests/
composer run check-syntax
composer run check-codestyle
vendor/bin/phpstan analyse --memory-limit=1G
git diff --check
```

All checks passed locally.

## Related Issue

Fixes #845