### PR TITLE
Add Wordpress registration form integration to backend (add new user)

### DIFF
--- a/integrations/wp-registration-form/class-registration-form.php
+++ b/integrations/wp-registration-form/class-registration-form.php
@@ -34,6 +34,8 @@ class MC4WP_Registration_Form_Integration extends MC4WP_User_Integration
             add_action('um_after_register_fields', [ $this, 'maybe_output_checkbox' ], 20);
             add_action('register_form', [ $this, 'maybe_output_checkbox' ], 20);
             add_action('woocommerce_register_form', [ $this, 'maybe_output_checkbox' ], 20);
+            add_action('user_new_form', [ $this, 'maybe_output_user_new_checkbox' ], 20);
+
         }
 
         add_action('um_user_register', [ $this, 'subscribe_from_registration' ], 90, 1);
@@ -45,6 +47,35 @@ class MC4WP_Registration_Form_Integration extends MC4WP_User_Integration
         }
     }
 
+/**
+ * Output checkbox in the admin "Add New User" form.
+ */
+public function maybe_output_user_new_checkbox($form_type)
+{
+    if ('add-new-user' !== $form_type || $this->shown) {
+        return;
+    }
+
+    $this->shown = true;
+    $this->output_user_new_checkbox();
+}
+
+/**
+ * Output checkbox as a form-table row.
+ */
+public function output_user_new_checkbox()
+{
+    $checkbox_id = esc_attr($this->checkbox_name);
+    echo '<table class="form-table" role="presentation">';
+    echo '<tr>';
+    echo '<th scope="row">', esc_html__('Mailchimp subscribe', 'mailchimp-for-wp'), '</th>';
+    echo '<td>';
+    $this->output_checkbox();
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+}
+
     /**
      * Output checkbox, once.
      */
@@ -55,6 +86,7 @@ class MC4WP_Registration_Form_Integration extends MC4WP_User_Integration
             $this->shown = true;
         }
     }
+
 
     /**
      * Subscribes from WP Registration Form

--- a/integrations/wp-registration-form/class-registration-form.php
+++ b/integrations/wp-registration-form/class-registration-form.php
@@ -46,34 +46,34 @@ class MC4WP_Registration_Form_Integration extends MC4WP_User_Integration
         }
     }
 
-/**
- * Output checkbox in the admin "Add New User" form.
- */
-public function maybe_output_user_new_checkbox($form_type)
-{
-    if ('add-new-user' !== $form_type || $this->shown) {
-        return;
+    /**
+     * Output checkbox in the admin "Add New User" form.
+     */
+    public function maybe_output_user_new_checkbox($form_type)
+    {
+        if ('add-new-user' !== $form_type || $this->shown) {
+            return;
+        }
+
+        $this->shown = true;
+        $this->output_user_new_checkbox();
     }
 
-    $this->shown = true;
-    $this->output_user_new_checkbox();
-}
-
-/**
- * Output checkbox as a form-table row.
- */
-public function output_user_new_checkbox()
-{
-    $checkbox_id = esc_attr($this->checkbox_name);
-    echo '<table class="form-table" role="presentation">';
-    echo '<tr>';
-    echo '<th scope="row">', esc_html__('Mailchimp subscribe', 'mailchimp-for-wp'), '</th>';
-    echo '<td>';
-    $this->output_checkbox();
-    echo '</td>';
-    echo '</tr>';
-    echo '</table>';
-}
+    /**
+     * Output checkbox as a form-table row.
+     */
+    public function output_user_new_checkbox()
+    {
+        $checkbox_id = esc_attr($this->checkbox_name);
+        echo '<table class="form-table" role="presentation">';
+        echo '<tr>';
+        echo '<th scope="row">', esc_html__('Mailchimp subscribe', 'mailchimp-for-wp'), '</th>';
+        echo '<td>';
+        $this->output_checkbox();
+        echo '</td>';
+        echo '</tr>';
+        echo '</table>';
+    }
 
     /**
      * Output checkbox, once.

--- a/integrations/wp-registration-form/class-registration-form.php
+++ b/integrations/wp-registration-form/class-registration-form.php
@@ -35,7 +35,6 @@ class MC4WP_Registration_Form_Integration extends MC4WP_User_Integration
             add_action('register_form', [ $this, 'maybe_output_checkbox' ], 20);
             add_action('woocommerce_register_form', [ $this, 'maybe_output_checkbox' ], 20);
             add_action('user_new_form', [ $this, 'maybe_output_user_new_checkbox' ], 20);
-
         }
 
         add_action('um_user_register', [ $this, 'subscribe_from_registration' ], 90, 1);
@@ -87,7 +86,6 @@ public function output_user_new_checkbox()
         }
     }
 
-
     /**
      * Subscribes from WP Registration Form
      *
@@ -97,7 +95,6 @@ public function output_user_new_checkbox()
      */
     public function subscribe_from_registration($user_id)
     {
-
         // was sign-up checkbox checked?
         if (! $this->triggered()) {
             return false;


### PR DESCRIPTION
Tested:
- already worked when the integration was set to implicit  even before this change
- now shows checkbox if integration is activated and not set to implicit
- works when checkbox is checked
- does not trigger when checkbox not checked

Comment:
With this the Wordpress Registration Form integration could potentially be renamed to "Wordpress user Registration/Creation" or something like that. 