### PR TITLE
Use inline-block on procaptcha wrapper so it inherits form alignment

### DIFF
--- a/integrations/prosopo-procaptcha/class-procaptcha.php
+++ b/integrations/prosopo-procaptcha/class-procaptcha.php
@@ -276,7 +276,8 @@ class MC4WP_Procaptcha
 
         $this->is_in_use = true;
 
-        $html  = '<mc4wp-procaptcha class="mc4wp-procaptcha" style="display: block;">';
+        // inline-block lets the parent form's text-align propagate to the widget.
+        $html  = '<mc4wp-procaptcha class="mc4wp-procaptcha" style="display: inline-block;">';
         $html .= '<div class="mc4wp-procaptcha__captcha"></div>';
 
         // The element is optional, e.g. should be missing on the settings page.


### PR DESCRIPTION
Originally I added a Left/Center/Right toggle so users could work around themes (e.g. Woodmart) that center the surrounding form but leave the captcha widget hard-left:

<img width="968" height="605" alt="image" src="https://github.com/user-attachments/assets/78720b0b-a1ad-4b2a-87ca-1c4f88058249" />

Simpler fix: change the `<mc4wp-procaptcha>` wrapper from `display: block` to `display: inline-block`. Block-level elements ignore `text-align` on their parent; inline-block elements honor it. So the widget now inherits whatever alignment the surrounding form uses, and no user-facing setting is needed.

Verified locally against left/center/right parents with the real Prosopo widget.